### PR TITLE
Add support for WebHost using parallel startup

### DIFF
--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -4,29 +4,33 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
-    using NServiceBus;
 
     class NServiceBusHostedService : IHostedService
     {
-        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint, IServiceProvider serviceProvider)
+        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint)
         {
             this.startableEndpoint = startableEndpoint;
-            this.serviceProvider = serviceProvider;
         }
+
+        public IEndpointInstance Endpoint { get; private set; }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
+            Endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
                 .ConfigureAwait(false);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            return endpoint.Stop();
+            return Endpoint.Stop();
         }
 
-        IEndpointInstance endpoint;
+        public void UseServiceProvider(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
         readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IServiceProvider serviceProvider;
+        IServiceProvider serviceProvider;
     }
 }


### PR DESCRIPTION
The WebHost used by ASP.NET Core applications prior to ASP.NET Core 3.0 starts `IHostedServices` in parallel while the application is already up and running. This means that there can be incoming HTTP requests while the endpoint hasn't started and therefore the `IMessageSession` not available yet. This can cause problems when a request handler wants to inject a message session to send a message.

Based on @danielmarbach workaround [here](https://github.com/danielmarbach/AddNServiceBus/blob/master/src/AddNServiceBus/AddNServiceBusServiceCollectionExtensions.cs) I've used a similar approach to delay the factory method until the endpoint is initialized correctly.

* For this approach we can't use the `startableEndpoint.MessageSession` property which is a `Lazy<IMessageSession>`. If the lazy is being resolved to soon, it will throw an exception and stuck with that value from then on. Instead this code checks the `NServiceBusHostedService` whether it has been started already. This can be done in a polling manner to continue once the session is available.
* This code can't really be tied to a specific build target as even .NET Core 3.0 web apps can still use the `WebHost` and all .NET standard 2.0+ apps can use the generic host (which does not have these issues).
* I haven't verified that the singleton factory works as expected on concurrent requests yet.
* I haven't added @danielmarbach exception checking logic into the SpinWait. I'm not sure whether Daniel already verified this is necessary or what the behavior of the webhost would be when the hosted service fails to start.