### PR TITLE
Add IHostBuilder based configuration

### DIFF
--- a/src/NServiceBus.Extensions.Hosting.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Extensions.Hosting.Tests/APIApprovals.cs
@@ -10,7 +10,7 @@
         [Test]
         public void ApproveNServiceBus()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(ServiceCollectionExtensions).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(HostBuilderExtensions).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1,5 +1,9 @@
 namespace NServiceBus
 {
+    public class static HostBuilderExtensions
+    {
+        public static Microsoft.Extensions.Hosting.IHostBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder, System.Func<Microsoft.Extensions.Hosting.HostBuilderContext, NServiceBus.EndpointConfiguration> endpointConfigurationBuilder) { }
+    }
     public class static ServiceCollectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNServiceBus(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, NServiceBus.EndpointConfiguration configuration) { }

--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -4,6 +4,9 @@ namespace NServiceBus
     {
         public static Microsoft.Extensions.Hosting.IHostBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder, System.Func<Microsoft.Extensions.Hosting.HostBuilderContext, NServiceBus.EndpointConfiguration> endpointConfigurationBuilder) { }
     }
+}
+namespace NServiceBus.WebHost
+{
     public class static ServiceCollectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddNServiceBus(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, NServiceBus.EndpointConfiguration configuration) { }

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Microsoft.Extensions.Hosting;
+    using WebHost;
 
     /// <summary>
     /// Extension methods to configure NServiceBus for the .NET Core generic host.

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Extensions.Hosting
+﻿namespace NServiceBus
 {
     using System;
     using Microsoft.Extensions.Hosting;

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// Extension methods to configure NServiceBus for the .NET Core generic host.
+    /// </summary>
+    public static class HostBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the host to start an NServiceBus endpoint.
+        /// </summary>
+        public static IHostBuilder UseNServiceBus(this IHostBuilder hostBuilder, Func<HostBuilderContext, EndpointConfiguration> endpointConfigurationBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, serviceCollection) =>
+            {
+                var endpointConfiguration = endpointConfigurationBuilder(ctx);
+                serviceCollection.AddNServiceBus(endpointConfiguration);
+            });
+
+            return hostBuilder;
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus
+﻿namespace NServiceBus.WebHost
 {
     using Extensions.Hosting;
     using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +12,10 @@
         /// <summary>
         /// Adds NServiceBus, IMessageSession, and related services to the IServiceCollection.
         /// </summary>
+        /// <remarks>
+        /// Use this extension method with WebHost only.
+        /// For GenericHost or ASP.NET Core version 3 or above use <see cref="HostBuilderExtensions.UseNServiceBus"/>
+        /// </remarks>
         public static IServiceCollection AddNServiceBus(this IServiceCollection services, EndpointConfiguration configuration)
         {
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(configuration, new ServiceCollectionAdapter(services));


### PR DESCRIPTION
Looking more into the generic host builder, the future approach to register dedicated services like NServiceBus should probably look more like this instead of extension methods on top of `IServiceCollection`.

The main reason for this is that extension methods on top of `IServiceCollection` do not appropriately reflect that we heavily depend on the generic host's `IHostedService` functionality. While `IServiceCollection` is part of MS.Extensions.DependencyInjection, it doesn't guarantee that the servicecollection we use `AddNServiceBus` to is being run as part of a host setup. By targeting the configuration on the actual host APIs, we're sure that there is a host (and we even know it's a generic one  cc @andreasohlund ).

so the recommended usage would look something like this:

```
Host.CreateDefaultBuilder(args)
    .UseNServiceBus(hostContext => new EndpointConfiguration("MyEndpoint"))
    .ConfigureWebHostDefaults(webBuilder =>
                {
                    webBuilder.UseStartup<Startup>();
                });
```

The existing `AddNServiceBus` API should still remain there for integration with pre-.NET Core 3.0 ASP.NET apps which use the WebHostBuilder. In that case, the `serviceCollection.AddNServiceBus(...)` approach would probably still be the recommended way (and we don't have to take a dependency on IWebHostBuilder from the ASP.NET Core packages)