### PR TITLE
Use transient registrations when using the WebHost

### DIFF
--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -1,8 +1,9 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using Extensions.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using WebHost;
 
     /// <summary>
     /// Extension methods to configure NServiceBus for the .NET Core generic host.
@@ -17,7 +18,17 @@
             hostBuilder.ConfigureServices((ctx, serviceCollection) =>
             {
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
-                serviceCollection.AddNServiceBus(endpointConfiguration);
+                var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
+                    endpointConfiguration, 
+                    new ServiceCollectionAdapter(serviceCollection));
+
+                serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
+                serviceCollection.AddSingleton<IHostedService>(serviceProvider =>
+                {
+                    var hostedService = new NServiceBusHostedService(startableEndpoint);
+                    hostedService.Configure(serviceProvider);
+                    return hostedService;
+                });
             });
 
             return hostBuilder;

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -4,29 +4,33 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
-    using NServiceBus;
 
     class NServiceBusHostedService : IHostedService
     {
-        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint, IServiceProvider serviceProvider)
+        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint)
         {
             this.startableEndpoint = startableEndpoint;
-            this.serviceProvider = serviceProvider;
         }
+
+        public IEndpointInstance Endpoint { get; private set; }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
+            Endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
                 .ConfigureAwait(false);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            return endpoint.Stop();
+            return Endpoint.Stop();
         }
 
-        IEndpointInstance endpoint;
+        public void Configure(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
         readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IServiceProvider serviceProvider;
+        IServiceProvider serviceProvider;
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
@@ -13,15 +13,22 @@
         /// Adds NServiceBus, IMessageSession, and related services to the IServiceCollection.
         /// </summary>
         /// <remarks>
-        /// Use this extension method with WebHost only.
-        /// For GenericHost or ASP.NET Core version 3 or above use <see cref="HostBuilderExtensions.UseNServiceBus"/>
+        /// Use this extension method with the ASP.NET Core WebHost only.
+        /// For GenericHost or ASP.NET Core version 3 or above use <see cref="HostBuilderExtensions.UseNServiceBus" />
         /// </remarks>
         public static IServiceCollection AddNServiceBus(this IServiceCollection services, EndpointConfiguration configuration)
         {
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(configuration, new ServiceCollectionAdapter(services));
-
-            services.AddSingleton(_ => startableEndpoint.MessageSession.Value);
-            services.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(startableEndpoint, serviceProvider));
+            var hostedService = new NServiceBusHostedService(startableEndpoint);
+            // When there is a chance that the application is hosted using the WebHost, do not use the Lazy property
+            // on the startableEndpoint as an early resolve will lock it into throwing an exception for the rest of
+            // the applications lifetime.
+            services.AddTransient<IMessageSession>(_ => hostedService.Endpoint);
+            services.AddSingleton<IHostedService>(serviceProvider =>
+            {
+                hostedService.Configure(serviceProvider);
+                return hostedService;
+            });
 
             return services;
         }


### PR DESCRIPTION
When there is a chance that the app is hosted in the WebHost (which starts hosted service while the web server already accepts requests) we need to avoid resolving the MesssageSession in a singleton scope and resolving it from the lazy property:
* If IMessageSession is resolved too early, it will access the lazy property which will throw an exception due to the endpoint not being started yet. The lazy will then always return this exception as the lazy won't evaluate again and even after the endpoint has been started, the property will continue to throw.
* In addition, due to the singleton registration, the exception will also be cached and rethrown on the container level too.

In this scenario, we should always resolve the MessageSession on every request. This means that it can be null while the endpoint hasn't started yet but once the endpoint has been started, the session value is correctly resolved from the container.
I've kept the existing code when using the generic host-specific APIs as in these cases it should be safe as the service has always been started and there is no risk in resolving the lazy or to cache it's value.