### PR TITLE
Changes Microsoft.Extensions.Hosting reference to [2.1.0, 3.0.0).

### DIFF
--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.2.0, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="All" />


### PR DESCRIPTION
Hi,

 Can't see any reason why this library couldn't target the `2.x` version of `Microsoft.Extensions.Hosting` as well as `3.0.0`.
