### PR TITLE
Support 3rd party containers implementing Microsoft's DI abstraction

### DIFF
--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
@@ -14,8 +14,7 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
-                var settings = endpointConfiguration.UseContainer(new AutofacServiceProviderFactory());
-                settings.ConfigureContainer(c => c.RegisterModule<AutofacPropertyInjectionModule>());
+                endpointConfiguration.UseContainer(new AutofacServiceProviderFactory(c => c.RegisterModule<AutofacPropertyInjectionModule>()));
 
                 configurationBuilderCustomization(endpointConfiguration);
             });

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
@@ -7,8 +7,7 @@
     using Autofac.Core;
     using Autofac.Core.Registration;
     using Autofac.Extensions.DependencyInjection;
-    using Extensions.Hosting;
-
+ 
     public class DefaultServer : ExternallyManagedContainerServer
     {
         public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/DefaultServer.cs
@@ -1,0 +1,33 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+    using Autofac;
+    using Autofac.Core;
+    using Autofac.Core.Registration;
+    using Autofac.Extensions.DependencyInjection;
+    using Extensions.Hosting;
+
+    public class DefaultServer : ExternallyManagedContainerServer
+    {
+        public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        {
+            return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
+            {
+                var settings = endpointConfiguration.UseContainer(new AutofacServiceProviderFactory());
+                settings.ConfigureContainer(c => c.RegisterModule<AutofacPropertyInjectionModule>());
+
+                configurationBuilderCustomization(endpointConfiguration);
+            });
+        }
+    }
+
+    class AutofacPropertyInjectionModule : Module
+    {
+        protected override void AttachToComponentRegistration(IComponentRegistryBuilder componentRegistry, IComponentRegistration registration)
+        {
+            registration.Activating += (sender, args) => args.Context.InjectProperties(args.Instance);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\**\DefaultServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac/TestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests {
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc { get; } = false;
+        public bool SupportsCrossQueueTransactions { get; } = false;
+        public bool SupportsNativePubSub { get; } = true;
+        public bool SupportsNativeDeferral { get; } = true;
+        public bool SupportsOutbox { get; } = false;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        {
+            return new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        }
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration()
+        {
+            return new ConfigureEndpointLearningPersistence(true);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
@@ -5,6 +5,7 @@
     using AcceptanceTesting.Support;
     using Lamar;
     using MessageInterfaces.MessageMapper.Reflection;
+    using Microsoft.Extensions.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -16,7 +17,7 @@
                 containerSettings.ConfigureContainer(registry =>
                 {
                     registry.Policies.SetAllProperties(setterConvention => setterConvention.WithAnyTypeFromNamespace("NServiceBus.AcceptanceTests"));
-                    registry.Policies.FillAllPropertiesOfType<IMessageCreator>().Use<MessageMapper>();
+                    registry.Policies.FillAllPropertiesOfType<IMessageCreator>();
                 });
 
                 configurationBuilderCustomization(endpointConfiguration);

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
@@ -4,8 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using Lamar;
-    using MessageInterfaces.MessageMapper.Reflection;
-    using Microsoft.Extensions.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/DefaultServer.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
+    using Lamar;
+    using MessageInterfaces.MessageMapper.Reflection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -10,6 +12,13 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
+                var containerSettings = endpointConfiguration.UseContainer<ServiceRegistry>(new LamarServiceProviderFactory());
+                containerSettings.ConfigureContainer(registry =>
+                {
+                    registry.Policies.SetAllProperties(setterConvention => setterConvention.WithAnyTypeFromNamespace("NServiceBus.AcceptanceTests"));
+                    registry.Policies.FillAllPropertiesOfType<IMessageCreator>().Use<MessageMapper>();
+                });
+
                 configurationBuilderCustomization(endpointConfiguration);
             });
         }

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\**\DefaultServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar/TestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests {
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc { get; } = false;
+        public bool SupportsCrossQueueTransactions { get; } = false;
+        public bool SupportsNativePubSub { get; } = true;
+        public bool SupportsNativeDeferral { get; } = true;
+        public bool SupportsOutbox { get; } = false;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        {
+            return new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        }
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration()
+        {
+            return new ConfigureEndpointLearningPersistence(true);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\**\DefaultServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/TestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests {
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc { get; } = false;
+        public bool SupportsCrossQueueTransactions { get; } = false;
+        public bool SupportsNativePubSub { get; } = true;
+        public bool SupportsNativeDeferral { get; } = true;
+        public bool SupportsOutbox { get; } = false;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        {
+            return new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        }
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration()
+        {
+            return new ConfigureEndpointLearningPersistence(true);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap/TestSuiteConstraints.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTests {
+﻿namespace NServiceBus.AcceptanceTests
+{
     using AcceptanceTesting.Support;
 
     public partial class TestSuiteConstraints

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+    using Autofac.Extensions.DependencyInjection;
+    using Extensions.Hosting;
+
+    public class DefaultServer : ExternallyManagedContainerServer
+    {
+        public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        {
+            return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
+            {
+                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+                configurationBuilderCustomization(endpointConfiguration);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -7,6 +7,7 @@
     using Castle.Windsor.MsDependencyInjection;
     using Extensions.Hosting;
     using Lamar;
+    using StructureMap;
     using Unity;
     using Unity.Microsoft.DependencyInjection;
 
@@ -19,7 +20,8 @@
 //                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 //                endpointConfiguration.UseServiceProviderFactory<ServiceRegistry>(new LamarServiceProviderFactory());
 //                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
-                endpointConfiguration.UseServiceProviderFactory<IUnityContainer>(new ServiceProviderFactory(null));
+//                endpointConfiguration.UseServiceProviderFactory<IUnityContainer>(new ServiceProviderFactory(null));
+                endpointConfiguration.UseServiceProviderFactory(new StructureMapServiceProviderFactory(new Registry()));
 
                 configurationBuilderCustomization(endpointConfiguration);
             });

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -5,6 +5,7 @@
     using AcceptanceTesting.Support;
     using Autofac.Extensions.DependencyInjection;
     using Extensions.Hosting;
+    using Lamar;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -12,7 +13,9 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
-                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+//                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+                endpointConfiguration.UseServiceProviderFactory<ServiceRegistry>(new LamarServiceProviderFactory());
+
                 configurationBuilderCustomization(endpointConfiguration);
             });
         }

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using Autofac.Extensions.DependencyInjection;
+    using Castle.Windsor.MsDependencyInjection;
     using Extensions.Hosting;
     using Lamar;
 
@@ -14,7 +15,8 @@
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
 //                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
-                endpointConfiguration.UseServiceProviderFactory<ServiceRegistry>(new LamarServiceProviderFactory());
+//                endpointConfiguration.UseServiceProviderFactory<ServiceRegistry>(new LamarServiceProviderFactory());
+                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
 
                 configurationBuilderCustomization(endpointConfiguration);
             });

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -4,13 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
-    using Castle.Windsor.MsDependencyInjection;
-    using Extensions.Hosting;
-    using Lamar;
-    using Microsoft.Extensions.DependencyInjection;
-    using StructureMap;
-    using Unity;
-    using Unity.Microsoft.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -19,8 +12,6 @@
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
 //                endpointConfiguration.UseContainer<ServiceRegistry>(new LamarServiceProviderFactory());
-                //                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
-                //                endpointConfiguration.UseServiceProviderFactory<IUnityContainer>(new ServiceProviderFactory(null));
                 //                endpointConfiguration.UseContainer(new StructureMapServiceProviderFactory(new Registry()));
                 //endpointConfiguration.UseContainer(new DefaultServiceProviderFactory());
 

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -4,8 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
-    using Autofac;
-    using Autofac.Extensions.DependencyInjection;
     using Castle.Windsor.MsDependencyInjection;
     using Extensions.Hosting;
     using Lamar;
@@ -20,17 +18,6 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
-                endpointConfiguration.UseContainer(new AutofacServiceProviderFactory(c =>
-                {
-                    var types = endpointCustomizationConfiguration.GetTypesScopedByTestClass();
-                    foreach (var type in types)
-                    {
-                        if (IsMessageHandler(type))
-                        {
-                            c.RegisterType(type).AsImplementedInterfaces().AsSelf().PropertiesAutowired(PropertyWiringOptions.AllowCircularDependencies);
-                        }
-                    }
-                }));
 //                endpointConfiguration.UseContainer<ServiceRegistry>(new LamarServiceProviderFactory());
                 //                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
                 //                endpointConfiguration.UseServiceProviderFactory<IUnityContainer>(new ServiceProviderFactory(null));

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/DefaultServer.cs
@@ -7,6 +7,8 @@
     using Castle.Windsor.MsDependencyInjection;
     using Extensions.Hosting;
     using Lamar;
+    using Unity;
+    using Unity.Microsoft.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -16,7 +18,8 @@
             {
 //                endpointConfiguration.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 //                endpointConfiguration.UseServiceProviderFactory<ServiceRegistry>(new LamarServiceProviderFactory());
-                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
+//                endpointConfiguration.UseServiceProviderFactory(new WindsorServiceProviderFactory());
+                endpointConfiguration.UseServiceProviderFactory<IUnityContainer>(new ServiceProviderFactory(null));
 
                 configurationBuilderCustomization(endpointConfiguration);
             });

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
+    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -6,10 +6,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
-    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
-    <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
+    <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\**\DefaultServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -6,7 +6,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Autofac" Version="5.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -6,8 +6,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.0.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/NServiceBus.Extensions.Hosting.AcceptanceTests.csproj
@@ -30,4 +30,9 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup Label="Ignore the tests with property injection until core is updated with PR https://github.com/Particular/NServiceBus/pull/5578">
+    <Compile Remove="\**\DataBus\**\When_using_custom_IDataBus.cs" />
+    <Compile Remove="\**\Sagas\**\When_sagas_cant_be_found.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.Extensions.Hosting.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.AcceptanceTests/TestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests {
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc { get; } = false;
+        public bool SupportsCrossQueueTransactions { get; } = false;
+        public bool SupportsNativePubSub { get; } = true;
+        public bool SupportsNativeDeferral { get; } = true;
+        public bool SupportsOutbox { get; } = false;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        {
+            return new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        }
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration()
+        {
+            return new ConfigureEndpointLearningPersistence(true);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/DefaultServer.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+    using Castle.Windsor.MsDependencyInjection;
+    using Extensions.Hosting;
+
+    public class DefaultServer : ExternallyManagedContainerServer
+    {
+        public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        {
+            return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
+            {
+                // property injection working OOTB
+                endpointConfiguration.UseContainer(new WindsorServiceProviderFactory());
+
+                configurationBuilderCustomization(endpointConfiguration);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/DefaultServer.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using Castle.Windsor.MsDependencyInjection;
-    using Extensions.Hosting;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\**\DefaultServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/Should_inject_properties_in_user_dependencies.cs
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/Should_inject_properties_in_user_dependencies.cs
@@ -1,0 +1,98 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using Castle.Windsor.MsDependencyInjection;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_injecting_custom_types
+    {
+        [Test]
+        public async Task Should_allow_registration_via_native_api()
+        {
+            var context = await Scenario.Define<TestContext>()
+                .WithEndpoint<TestEndpoint>(e => e.When(s => s.SendLocal(new MyMessage())))
+                .Done(c => c.GotTheMessage)
+                .Run();
+
+            Assert.True(context.DependencyAvailable);
+        }
+
+        class TestContext : ScenarioContext
+        {
+            public bool DependencyAvailable { get; set; }
+            public bool GotTheMessage { get; set; }
+        }
+
+        class TestEndpoint : EndpointConfigurationBuilder
+        {
+            public TestEndpoint()
+            {
+                EndpointSetup<CastleEndpoint>(c => c.GetSettings()
+                .Set<Action<ContainerSettings<IWindsorContainer>>>(cs =>
+                //windsor doesn't provide a config API via the service provider factory so we need to use our custom api
+                cs.ConfigureContainer(w => w.Register(Component.For<MyDependency>()))));
+            }
+
+            class MyHandler : IHandleMessages<MyMessage>
+            {
+                public MyHandler(TestContext testContext, MyDependency myDependency)
+                {
+                    this.testContext = testContext;
+                    this.myDependency = myDependency;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.DependencyAvailable = myDependency != null;
+                    testContext.GotTheMessage = true;
+                    return Task.CompletedTask;
+                }
+
+                readonly TestContext testContext;
+                readonly MyDependency myDependency;
+            }
+        }
+
+        class MyDependency
+        {
+        }
+
+        class MyMessage : IMessage
+        {
+        }
+
+        class CastleEndpoint : IEndpointSetupTemplate
+        {
+            public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+            {
+                var configuration = new EndpointConfiguration(runDescriptor.ScenarioContext.TestRunId.ToString("D"));
+
+                configuration.TypesToIncludeInScan(endpointConfiguration.GetTypesScopedByTestClass());
+                configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
+
+                configuration.UseTransport<LearningTransport>();
+
+                var containerSettings = configuration.UseContainer(new WindsorServiceProviderFactory());
+
+                if (configuration.GetSettings().TryGet<Action<ContainerSettings<IWindsorContainer>>>(out var containerCustomizations))
+                {
+                    containerCustomizations(containerSettings);
+                }
+
+                configurationBuilderCustomization(configuration);
+
+                return Task.FromResult(configuration);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/TestSuiteConstraints.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests {
+    using AcceptanceTesting.Support;
+
+    public partial class TestSuiteConstraints
+    {
+        public bool SupportsDtc { get; } = false;
+        public bool SupportsCrossQueueTransactions { get; } = false;
+        public bool SupportsNativePubSub { get; } = true;
+        public bool SupportsNativeDeferral { get; } = true;
+        public bool SupportsOutbox { get; } = false;
+
+        public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        {
+            return new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        }
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration()
+        {
+            return new ConfigureEndpointLearningPersistence(true);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests/TestSuiteConstraints.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTests {
+﻿namespace NServiceBus.AcceptanceTests
+{
     using AcceptanceTesting.Support;
 
     public partial class TestSuiteConstraints

--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1,3 +1,10 @@
+namespace NServiceBus.Extensions.Hosting
+{
+    public class static ContainerExtensions
+    {
+        public static void UseContainer<TContainerBuilder>(this NServiceBus.EndpointConfiguration configuration, Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TContainerBuilder> serviceProviderFactory) { }
+    }
+}
 namespace NServiceBus
 {
     public class static HostBuilderExtensions

--- a/src/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.1" />
+    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Extensions.Hosting\NServiceBus.Extensions.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests/Should_inject_properties_in_user_dependencies.cs
+++ b/src/NServiceBus.Extensions.Hosting.Unity.AcceptanceTests/Should_inject_properties_in_user_dependencies.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using Unity;
+    using Unity.Microsoft.DependencyInjection;
+
+    [TestFixture]
+    public class Should_inject_properties_in_user_dependencies
+    {
+        [Test]
+        public async Task Should_support_property_injection()
+        {
+            await Scenario.Define<TestContext>()
+                .WithEndpoint<TestEndpoint>(e => e
+                    .When(s => s.SendLocal(new TestMessage())))
+                .Done(c => c.PropertyInjected)
+                .Run();
+        }
+
+        class TestContext : ScenarioContext
+        {
+            public bool PropertyInjected { get; set; }
+        }
+
+        class TestEndpoint : EndpointConfigurationBuilder
+        {
+            public TestEndpoint()
+            {
+                EndpointSetup<EndpointTemplate>();
+            }
+
+            class TestHandler : IHandleMessages<TestMessage>
+            {
+                [Dependency] // property injection requires attributes defined by the user
+                public TestContext TestContext { get; set; }
+
+                public Task Handle(TestMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.PropertyInjected = TestContext != null;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class TestMessage : IMessage
+        {
+        }
+    }
+
+    class EndpointTemplate : IEndpointSetupTemplate
+    {
+        public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        {
+            var configuration = new EndpointConfiguration(runDescriptor.ScenarioContext.TestRunId.ToString("D"));
+            configuration.UseTransport<LearningTransport>();
+
+            var containerSettings = configuration.UseContainer<IUnityContainer>(new ServiceProviderFactory(null));
+            containerSettings.ServiceCollection.AddSingleton(runDescriptor.ScenarioContext.GetType(), runDescriptor.ScenarioContext);
+
+            configurationBuilderCustomization(configuration);
+            return Task.FromResult(configuration);
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.AcceptanceTests", "NServiceBus.Extensions.Hosting.AcceptanceTests\NServiceBus.Extensions.Hosting.AcceptanceTests.csproj", "{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{A97C68F9-5695-4065-958F-5AF16568A2C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A97C68F9-5695-4065-958F-5AF16568A2C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A97C68F9-5695-4065-958F-5AF16568A2C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Host
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap", "NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap\NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap.csproj", "{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar", "NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar\NServiceBus.Extensions.Hosting.AcceptanceTests.Lamar.csproj", "{43F17AE9-5462-44FF-A6C4-C9E44227CBC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43F17AE9-5462-44FF-A6C4-C9E44227CBC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43F17AE9-5462-44FF-A6C4-C9E44227CBC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43F17AE9-5462-44FF-A6C4-C9E44227CBC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43F17AE9-5462-44FF-A6C4-C9E44227CBC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -13,7 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.AcceptanceTests", "NServiceBus.Extensions.Hosting.AcceptanceTests\NServiceBus.Extensions.Hosting.AcceptanceTests.csproj", "{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests", "NServiceBus.Extensions.Hosting.AcceptanceTests\NServiceBus.Extensions.Hosting.AcceptanceTests.csproj", "{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac", "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac\NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj", "{CDD2AF76-D7E5-49BD-B334-F011B3E56653}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Host
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests", "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests\NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj", "{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests", "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests\NServiceBus.Extensions.Hosting.Unity.AcceptanceTests.csproj", "{FF832582-FD62-4F6B-9692-A268E71132F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF832582-FD62-4F6B-9692-A268E71132F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF832582-FD62-4F6B-9692-A268E71132F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF832582-FD62-4F6B-9692-A268E71132F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF832582-FD62-4F6B-9692-A268E71132F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -17,9 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Host
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac", "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac\NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj", "{CDD2AF76-D7E5-49BD-B334-F011B3E56653}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests", "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests\NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj", "{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests", "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests\NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj", "{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests", "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests\NServiceBus.Extensions.Hosting.Unity.AcceptanceTests.csproj", "{FF832582-FD62-4F6B-9692-A268E71132F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests", "NServiceBus.Extensions.Hosting.Unity.AcceptanceTests\NServiceBus.Extensions.Hosting.Unity.AcceptanceTests.csproj", "{FF832582-FD62-4F6B-9692-A268E71132F5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap", "NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap\NServiceBus.Extensions.Hosting.AcceptanceTests.StructureMap.csproj", "{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{FF832582-FD62-4F6B-9692-A268E71132F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF832582-FD62-4F6B-9692-A268E71132F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF832582-FD62-4F6B-9692-A268E71132F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD96BE4C-3A9B-45E0-85EC-C8023CFD57ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting.sln
+++ b/src/NServiceBus.Extensions.Hosting.sln
@@ -15,7 +15,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests", "NServiceBus.Extensions.Hosting.AcceptanceTests\NServiceBus.Extensions.Hosting.AcceptanceTests.csproj", "{75F37F0A-032C-42EB-8AC4-CC9CB9965B66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac", "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac\NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj", "{CDD2AF76-D7E5-49BD-B334-F011B3E56653}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac", "NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac\NServiceBus.Extensions.Hosting.AcceptanceTests.Autofac.csproj", "{CDD2AF76-D7E5-49BD-B334-F011B3E56653}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests", "NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests\NServiceBus.Extensions.Hosting.CastleWindsor.AcceptanceTests.csproj", "{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDD2AF76-D7E5-49BD-B334-F011B3E56653}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE74932F-FF83-4B3B-8CE7-5FD317A88C57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Extensions.Hosting/ContainerAdapter.cs
+++ b/src/NServiceBus.Extensions.Hosting/ContainerAdapter.cs
@@ -1,0 +1,144 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Microsoft.Extensions.DependencyInjection;
+    using ObjectBuilder;
+    using ObjectBuilder.Common;
+
+    class ContainerAdapter<TContainerBuilder> : IContainer
+    {
+        public ContainerAdapter(IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
+        {
+            serviceCollectionAdapter = new ServiceCollectionAdapter(collection);
+            serviceProviderAdapter = new Lazy<ServiceProviderAdapter>(() =>
+            {
+                locked = true;
+                var containerBuilder = serviceProviderFactory.CreateBuilder(collection);
+                var serviceProvider = serviceProviderFactory.CreateServiceProvider(containerBuilder);
+                return new ServiceProviderAdapter(serviceProvider);
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public void Dispose()
+        {
+            serviceProviderAdapter.Value.Dispose();
+        }
+
+        public object Build(Type typeToBuild)
+        {
+            return serviceProviderAdapter.Value.Build(typeToBuild);
+        }
+
+        public IContainer BuildChildContainer()
+        {
+            return new ChildContainerAdapter(serviceProviderAdapter.Value.CreateChildBuilder());
+        }
+
+        public IEnumerable<object> BuildAll(Type typeToBuild)
+        {
+            return serviceProviderAdapter.Value.BuildAll(typeToBuild);
+        }
+
+        public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
+        {
+            ThrowOnLockedContainer();
+
+            serviceCollectionAdapter.ConfigureComponent(component, dependencyLifecycle);
+        }
+
+        public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
+        {
+            ThrowOnLockedContainer();
+
+            serviceCollectionAdapter.ConfigureComponent(component, dependencyLifecycle);
+        }
+
+        public void RegisterSingleton(Type lookupType, object instance)
+        {
+            ThrowOnLockedContainer();
+
+            serviceCollectionAdapter.RegisterSingleton(lookupType, instance);
+        }
+
+        public bool HasComponent(Type componentType)
+        {
+            return serviceCollectionAdapter.HasComponent(componentType);
+        }
+
+        public void Release(object instance)
+        {
+            serviceProviderAdapter.Value.Release(instance);
+        }
+
+        void ThrowOnLockedContainer()
+        {
+            if (locked)
+            {
+                throw new InvalidOperationException("This operation is not valid anymore because the container has been locked.");
+            }
+        }
+
+        readonly ServiceCollectionAdapter serviceCollectionAdapter;
+        readonly ServiceCollection collection = new ServiceCollection();
+        readonly Lazy<ServiceProviderAdapter> serviceProviderAdapter;
+
+        bool locked;
+
+        class ChildContainerAdapter : IContainer
+        {
+            public ChildContainerAdapter(IBuilder childBuilder)
+            {
+                builder = childBuilder;
+            }
+
+            public void Dispose()
+            {
+                builder.Dispose();
+            }
+
+            public object Build(Type typeToBuild)
+            {
+                return builder.Build(typeToBuild);
+            }
+
+            public IContainer BuildChildContainer()
+            {
+                throw new InvalidOperationException("Cannot build further child containers on a child container.");
+            }
+
+            public IEnumerable<object> BuildAll(Type typeToBuild)
+            {
+                return builder.BuildAll(typeToBuild);
+            }
+
+            public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
+            {
+                throw new InvalidOperationException("Cannot configure services on a child container.");
+            }
+
+            public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
+            {
+                throw new InvalidOperationException("Cannot configure services on a child container.");
+            }
+
+            public void RegisterSingleton(Type lookupType, object instance)
+            {
+                throw new InvalidOperationException("Cannot configure services on a child container.");
+            }
+
+            public bool HasComponent(Type componentType)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public void Release(object instance)
+            {
+                builder.Release(instance);
+            }
+
+            readonly IBuilder builder;
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
@@ -1,0 +1,147 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Microsoft.Extensions.DependencyInjection;
+    using ObjectBuilder;
+    using ObjectBuilder.Common;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class ContainerExtensions
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        //TODO: Action<TContainerBuilder> param
+        public static void UseServiceProviderFactory<TContainerBuilder>(this EndpointConfiguration configuration, 
+            IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
+        {
+            IContainer containerAdapter = new ContainerAdapter<TContainerBuilder>(serviceProviderFactory);
+            configuration.UseContainer(containerAdapter);
+        }
+    }
+
+    class ContainerAdapter<TContainerBuilder> : IContainer
+    {
+        ServiceCollectionAdapter scAdapter;
+        ServiceCollection collection = new ServiceCollection();
+
+        Lazy<ServiceProviderAdapter> spAdapter;
+
+
+        public ContainerAdapter(IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
+        {
+            scAdapter = new ServiceCollectionAdapter(collection);
+            spAdapter = new Lazy<ServiceProviderAdapter>(
+                () =>
+                {
+                    var containerBuilder = serviceProviderFactory.CreateBuilder(collection);
+                    var serviceProvider = serviceProviderFactory.CreateServiceProvider(containerBuilder);
+                    return new ServiceProviderAdapter(serviceProvider);
+                }, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public void Dispose()
+        {
+            spAdapter.Value.Dispose();
+        }
+
+        public object Build(Type typeToBuild)
+        {
+            return spAdapter.Value.Build(typeToBuild);
+        }
+
+        public IContainer BuildChildContainer()
+        {
+            return new ChildContainerAdapter(spAdapter.Value.CreateChildBuilder());
+        }
+
+        public IEnumerable<object> BuildAll(Type typeToBuild)
+        {
+            return spAdapter.Value.BuildAll(typeToBuild);
+        }
+
+        public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
+        {
+            scAdapter.ConfigureComponent(component, dependencyLifecycle);
+        }
+
+        public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
+        {
+            scAdapter.ConfigureComponent(component, dependencyLifecycle);
+        }
+
+        public void RegisterSingleton(Type lookupType, object instance)
+        {
+            scAdapter.RegisterSingleton(lookupType, instance);
+        }
+
+        public bool HasComponent(Type componentType)
+        {
+            return scAdapter.HasComponent(componentType);
+        }
+
+        public void Release(object instance)
+        {
+            spAdapter.Value.Release(instance);
+        }
+
+        class ChildContainerAdapter : IContainer
+        {
+            readonly IBuilder builder;
+
+            public ChildContainerAdapter(IBuilder childBuilder)
+            {
+                builder = childBuilder;
+            }
+
+            public void Dispose()
+            {
+                builder.Dispose();
+            }
+
+            public object Build(Type typeToBuild)
+            {
+                return builder.Build(typeToBuild);
+            }
+
+            public IContainer BuildChildContainer()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<object> BuildAll(Type typeToBuild)
+            {
+                return builder.BuildAll(typeToBuild);
+            }
+
+            public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void RegisterSingleton(Type lookupType, object instance)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool HasComponent(Type componentType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Release(object instance)
+            {
+                builder.Release(instance);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
@@ -1,5 +1,6 @@
-﻿namespace NServiceBus.Extensions.Hosting
+﻿namespace NServiceBus
 {
+    using Extensions.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using ObjectBuilder.Common;
 

--- a/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ContainerExtensions.cs
@@ -1,147 +1,25 @@
 ﻿namespace NServiceBus.Extensions.Hosting
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
     using Microsoft.Extensions.DependencyInjection;
-    using ObjectBuilder;
     using ObjectBuilder.Common;
 
     /// <summary>
-    /// 
+    /// Extension methods to integrate containers support the Microsoft.Extensions.DependencyInjection model.
     /// </summary>
     public static class ContainerExtensions
     {
         /// <summary>
-        /// 
+        /// Use a custom dependency injection container implementing the Microsoft.Extensions.DependencyInjection model.
+        /// The container lifetime will be managed by NServiceBus.
+        /// Use <see cref="EndpointWithExternallyManagedContainer"/> to manage container lifecycle yourself.
         /// </summary>
-        //TODO: Action<TContainerBuilder> param
-        public static void UseServiceProviderFactory<TContainerBuilder>(this EndpointConfiguration configuration, 
+        /// <param name="configuration">The endpoint configuration.</param>
+        /// <param name="serviceProviderFactory">The <see cref="IServiceProviderFactory{TContainerBuilder}"/> of the container to be used.</param>
+        public static void UseContainer<TContainerBuilder>(this EndpointConfiguration configuration, 
             IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
         {
             IContainer containerAdapter = new ContainerAdapter<TContainerBuilder>(serviceProviderFactory);
             configuration.UseContainer(containerAdapter);
-        }
-    }
-
-    class ContainerAdapter<TContainerBuilder> : IContainer
-    {
-        ServiceCollectionAdapter scAdapter;
-        ServiceCollection collection = new ServiceCollection();
-
-        Lazy<ServiceProviderAdapter> spAdapter;
-
-
-        public ContainerAdapter(IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
-        {
-            scAdapter = new ServiceCollectionAdapter(collection);
-            spAdapter = new Lazy<ServiceProviderAdapter>(
-                () =>
-                {
-                    var containerBuilder = serviceProviderFactory.CreateBuilder(collection);
-                    var serviceProvider = serviceProviderFactory.CreateServiceProvider(containerBuilder);
-                    return new ServiceProviderAdapter(serviceProvider);
-                }, LazyThreadSafetyMode.ExecutionAndPublication);
-        }
-
-        public void Dispose()
-        {
-            spAdapter.Value.Dispose();
-        }
-
-        public object Build(Type typeToBuild)
-        {
-            return spAdapter.Value.Build(typeToBuild);
-        }
-
-        public IContainer BuildChildContainer()
-        {
-            return new ChildContainerAdapter(spAdapter.Value.CreateChildBuilder());
-        }
-
-        public IEnumerable<object> BuildAll(Type typeToBuild)
-        {
-            return spAdapter.Value.BuildAll(typeToBuild);
-        }
-
-        public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
-        {
-            scAdapter.ConfigureComponent(component, dependencyLifecycle);
-        }
-
-        public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
-        {
-            scAdapter.ConfigureComponent(component, dependencyLifecycle);
-        }
-
-        public void RegisterSingleton(Type lookupType, object instance)
-        {
-            scAdapter.RegisterSingleton(lookupType, instance);
-        }
-
-        public bool HasComponent(Type componentType)
-        {
-            return scAdapter.HasComponent(componentType);
-        }
-
-        public void Release(object instance)
-        {
-            spAdapter.Value.Release(instance);
-        }
-
-        class ChildContainerAdapter : IContainer
-        {
-            readonly IBuilder builder;
-
-            public ChildContainerAdapter(IBuilder childBuilder)
-            {
-                builder = childBuilder;
-            }
-
-            public void Dispose()
-            {
-                builder.Dispose();
-            }
-
-            public object Build(Type typeToBuild)
-            {
-                return builder.Build(typeToBuild);
-            }
-
-            public IContainer BuildChildContainer()
-            {
-                throw new NotImplementedException();
-            }
-
-            public IEnumerable<object> BuildAll(Type typeToBuild)
-            {
-                return builder.BuildAll(typeToBuild);
-            }
-
-            public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void RegisterSingleton(Type lookupType, object instance)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool HasComponent(Type componentType)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Release(object instance)
-            {
-                builder.Release(instance);
-            }
         }
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/ContainerSettings.cs
+++ b/src/NServiceBus.Extensions.Hosting/ContainerSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Extensions.Hosting
+﻿namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="Particular.Packaging" Version="0.5.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="\**\NServiceBus.TransportTests.Sources\**\DefaultServer.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Proposal

### Packaging

* To avoid confusion with the API targeting Generic Host usage, we intended to release this API as **a new, dedicated package**. The new package will not have a dependency on `NServiceBus.Extensions.Hosting`.
* The proposed **name for the new package is `NServiceBus.Microsoft.DependencyInjection`**. This is inconsistent with the naming of the package supporting the generic host which uses `NServiceBus.Extensions.Hosting` but most other packages use the `XYZ.Microsoft.DependencyInjection` convention (except Autofac). The TF felt that the proposed naming is clearer about integration with Microsoft's DI abstraction. Therefore, the code in this PR will be moved to a new repo after the RFC.

### API

`UseContainer` is today what the customers use when running in [internally managed mode](https://docs.particular.net/nservicebus/dependency-injection/#internally-managed-mode) so we decided to keep that name for the new overload to be consistent. Also, it helps users to understand that this another option of configuring the container, not having to combine new and existing APIs.
- [Code example](https://github.com/Particular/NServiceBus.Extensions.Hosting/pull/37/files#diff-2bdd912363727389947c00e74306c0c4R15)

The following advanced extension points are also made available via a strongly-typed settings class:
  - Expose `ServiceCollection` to give users a way to use that API to register components should they prefer to use it. This also allows users to configure other dependencies that supports integration with service collection.
    * Code example: [User provided dependency registration](https://github.com/Particular/NServiceBus.Extensions.Hosting/pull/37/files#diff-34486edbef863ff03cf22ad5f1368661R62-R63)
    * [User configuring `NLog`](https://github.com/NLog/NLog/wiki/Getting-started-with-.NET-Core-2---Console-application#32-setup-the-dependency-injector-di-container).
  - Expose a way to access the native container configuration. We need to do this since some of the containers, eg. Lamar and Castle only provides this access via extensions on the generic host which the users, in this case, are not using. 
    * Code example: [Lamar's container customization](https://github.com/Particular/NServiceBus.Extensions.Hosting/pull/37/files#diff-8e5866561dd4917c34e1e205f8d586e2R14-R19).

### Impact on users

- Property injection not available OOTB. Users who want to use property injection have to manually configure their container to support property injection.
  - Some containers don't support property injection at all or only with extensive workarounds.
  - When an easy way to enable property injection is available, we can provide doco snippets.
  - There is no common approach to enable property injection on user-provided types like message handlers or behaviours. Some containers allow this more easily while other requires complex workarounds.
  - While there is an option to provide a specific extension, type-level API which gives the user the ability to customize registrations for handlers and co, the TF feels we don't need this for v1 and we instead suggest to wait for feedback.
 will require users to customize eg. handler registrations using the native container API should the container have support for it. TF has verified that Autofac work and will verify all of the currently supported containers
- We currently can't support Spring.NET, SimpleInjector and Ninject due to missing/weird support of the MS.DI model.
- Verified that we support Autofac, Unity, Castle.Windsor, StructureMap and Lamar.