### PR TITLE
Make adding MessageSession to service collection optional

### DIFF
--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -13,18 +13,20 @@
         /// <summary>
         /// Configures the host to start an NServiceBus endpoint.
         /// </summary>
-        public static IHostBuilder UseNServiceBus(this IHostBuilder hostBuilder, Func<HostBuilderContext, EndpointConfiguration> endpointConfigurationBuilder)
+        public static IHostBuilder UseNServiceBus(this IHostBuilder hostBuilder, Func<HostBuilderContext, EndpointConfiguration> endpointConfigurationBuilder, bool addMessageSessionToServiceCollection = true)
         {
-            hostBuilder.ConfigureServices((ctx, serviceCollection) =>
+            return hostBuilder.ConfigureServices((ctx, serviceCollection) =>
             {
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
                 var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, new ServiceCollectionAdapter(serviceCollection));
 
-                serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
+                if (addMessageSessionToServiceCollection)
+                {
+					serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
+                }
                 serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(startableEndpoint, serviceProvider));
             });
 
-            return hostBuilder;
         }
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -22,7 +22,7 @@
 
                 if (addMessageSessionToServiceCollection)
                 {
-					serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
+                    serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
                 }
                 serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(startableEndpoint, serviceProvider));
             });

--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.2.0, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.7.0" PrivateAssets="All" />


### PR DESCRIPTION
@timbussmann I fully understand not wanting to expose things to your public API so here is the happy medium that lets everyone's existing implementations remain as-is but allows me to sidestep the one thing I need to do in order to get multiple message sessions wired up with this framework without maintaining my own version.

This is in regard to issue [#27](https://github.com/Particular/NServiceBus.Extensions.Hosting/issues/27)

I also updated the dependency on the hosting library to allow those of us on 3.1 to use the latest releases as everything seems to work fine when I do so locally.