### PR TITLE
Endpoint factory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+insert_final_newline = false
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+csharp_using_directive_placement = inside_namespace:error
+dotnet_style_require_accessibility_modifiers = never:error
+
+dotnet_naming_rule.private_fields.severity = warning
+dotnet_naming_rule.private_fields.symbols = private_fields
+dotnet_naming_rule.private_fields.style = private_prefix_style
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.required_modifiers = none
+
+dotnet_naming_style.private_prefix_style.capitalization = camel_case

--- a/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
@@ -1,26 +1,25 @@
 ﻿namespace NServiceBus.Extensions.Hosting
 {
-    using System;
+    using ObjectBuilder;
     using System.Threading.Tasks;
 
     class EndpointInstanceStarter : IEndpointInstanceStarter, IStoppableEndpoint
     {
         readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IServiceProvider serviceProvider;
+        readonly IBuilder builder;
 
         public EndpointInstanceStarter(
             IStartableEndpointWithExternallyManagedContainer startableEndpoint,
-            IServiceProvider serviceProvider)
+            IBuilder builder)
         {
             this.startableEndpoint = startableEndpoint;
-            this.serviceProvider = serviceProvider;
+            this.builder = builder;
         }
 
         /// <inheritdoc />
         public async Task<IStoppableEndpoint> Start()
         {
-            endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
-                .ConfigureAwait(false);
+            endpoint = await startableEndpoint.Start(builder).ConfigureAwait(false);
             return this;
         }
 

--- a/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
@@ -1,13 +1,10 @@
 ﻿namespace NServiceBus.Extensions.Hosting
 {
-    using ObjectBuilder;
     using System.Threading.Tasks;
+    using ObjectBuilder;
 
     class EndpointInstanceStarter : IEndpointInstanceStarter, IStoppableEndpoint
     {
-        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IBuilder builder;
-
         public EndpointInstanceStarter(
             IStartableEndpointWithExternallyManagedContainer startableEndpoint,
             IBuilder builder)
@@ -23,7 +20,13 @@
             return this;
         }
 
-        Task IStoppableEndpoint.Stop() => endpoint.Stop();
+        Task IStoppableEndpoint.Stop()
+        {
+            return endpoint.Stop();
+        }
+
+        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
+        readonly IBuilder builder;
 
         IEndpointInstance endpoint;
     }

--- a/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointInstanceStarter.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Threading.Tasks;
+
+    class EndpointInstanceStarter : IEndpointInstanceStarter, IStoppableEndpoint
+    {
+        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
+        readonly IServiceProvider serviceProvider;
+
+        public EndpointInstanceStarter(
+            IStartableEndpointWithExternallyManagedContainer startableEndpoint,
+            IServiceProvider serviceProvider)
+        {
+            this.startableEndpoint = startableEndpoint;
+            this.serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        public async Task<IStoppableEndpoint> Start()
+        {
+            endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
+                .ConfigureAwait(false);
+            return this;
+        }
+
+        Task IStoppableEndpoint.Stop() => endpoint.Stop();
+
+        IEndpointInstance endpoint;
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -15,13 +15,23 @@
         /// </summary>
         public static IHostBuilder UseNServiceBus(this IHostBuilder hostBuilder, Func<HostBuilderContext, EndpointConfiguration> endpointConfigurationBuilder)
         {
+            return hostBuilder.UseNServiceBus<EndpointInstanceStarter>(endpointConfigurationBuilder);
+        }
+
+        /// <summary>
+        /// Configure the host to start an NServiceBus endpoint using <typeparamref name="TEndpointInstanceStart" />.
+        /// </summary>
+        /// <typeparam name="TEndpointInstanceStart">Implementation of <see cref="IEndpointInstanceStarter" />.</typeparam>
+        public static IHostBuilder UseNServiceBus<TEndpointInstanceStart>(this IHostBuilder hostBuilder, Func<HostBuilderContext, EndpointConfiguration> endpointConfigurationBuilder) where TEndpointInstanceStart : class, IEndpointInstanceStarter
+        {
             hostBuilder.ConfigureServices((ctx, serviceCollection) =>
             {
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
                 var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, new ServiceCollectionAdapter(serviceCollection));
-
+                serviceCollection.AddSingleton(startableEndpoint);
+                serviceCollection.AddSingleton<IEndpointInstanceStarter, TEndpointInstanceStart>();
                 serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);
-                serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(startableEndpoint, serviceProvider));
+                serviceCollection.AddSingleton<IHostedService, NServiceBusHostedService>();
             });
 
             return hostBuilder;

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -4,6 +4,7 @@
     using Extensions.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+    using ObjectBuilder;
 
     /// <summary>
     /// Extension methods to configure NServiceBus for the .NET Core generic host.
@@ -28,6 +29,7 @@
             {
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
                 var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, new ServiceCollectionAdapter(serviceCollection));
+                serviceCollection.AddSingleton<IBuilder>(serviceProvider => new ServiceProviderAdapter(serviceProvider));
                 serviceCollection.AddSingleton(startableEndpoint);
                 serviceCollection.AddSingleton<IEndpointInstanceStarter, TEndpointInstanceStart>();
                 serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);

--- a/src/NServiceBus.Extensions.Hosting/IEndpointInstanceStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/IEndpointInstanceStarter.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Start <see cref="IEndpointInstance" /> instances.
+    /// </summary>
+    public interface IEndpointInstanceStarter
+    {
+        /// <summary>
+        /// Start endpoint instance.
+        /// </summary>
+        /// <returns></returns>
+        Task<IStoppableEndpoint> Start();
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/IStoppableEndpoint.cs
+++ b/src/NServiceBus.Extensions.Hosting/IStoppableEndpoint.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Stop started <see cref="IEndpointInstance" />.
+    /// </summary>
+    public interface IStoppableEndpoint
+    {
+        /// <summary>
+        /// Stop endpoint.
+        /// </summary>
+        /// <returns>
+        /// </returns>
+        Task Stop();
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -1,23 +1,19 @@
 ﻿namespace NServiceBus.Extensions.Hosting
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
-    using NServiceBus;
 
     class NServiceBusHostedService : IHostedService
     {
-        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint, IServiceProvider serviceProvider)
+        public NServiceBusHostedService(IEndpointInstanceStarter endpointInstanceStarter)
         {
-            this.startableEndpoint = startableEndpoint;
-            this.serviceProvider = serviceProvider;
+            this.endpointInstanceStarter = endpointInstanceStarter;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            endpoint = await startableEndpoint.Start(new ServiceProviderAdapter(serviceProvider))
-                .ConfigureAwait(false);
+            endpoint = await endpointInstanceStarter.Start().ConfigureAwait(false);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
@@ -25,8 +21,7 @@
             return endpoint.Stop();
         }
 
-        IEndpointInstance endpoint;
-        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IServiceProvider serviceProvider;
+        IStoppableEndpoint endpoint;
+        readonly IEndpointInstanceStarter endpointInstanceStarter;
     }
 }


### PR DESCRIPTION
This is a suggestion to tackle [retry functionality](https://github.com/Particular/NServiceBus.Extensions.Hosting/issues/24#issuecomment-641339765) for transports. 

* [ ] Breaking changes
* [ ] Add text file public API
* [ ] Bump version
* [ ] Code sample
* [ ] Documentation

## Background
Handle transport connection failures.

## Change
I've added couple abstractions that enable customization of startup behavior by implementing `IEndpointInstanceStarter`. It has one method `Start` that returns instance of  `IStoppableEndpoint`. This is the point in which a custom behavior can be added that do retries trying to re-establish connection to the chosen transport.

The default implementation doesn't change behavior and is just an extraction of what happened in the hosted service implementation. 

## New APIs
* `HostBuilderExtensions.UseNServiceBus<T>()`
* `IEndpointInstanceStarter` - Pass `CancellationToken` to `Start`?
    ```c#
    internal async Task Start(CancellationToken token)
    {
        // Example using Polly (https://github.com/App-vNext/Polly)
        var policy = Policy
                    .Handle<BrokerUnreachableException>()
                    .RetryForeverAsync();
        endpoint = await policy.ExecuteAsync(_ => starter(), token, false);
    }
    ```
* `IStoppableEndpoint`

**Edit**
~~Current proposal would benefit from making `ServiceProviderAdapter` or abstract the starting of the endpoint to hide adapter. We can implement it explicitly but it will lead to `Build` and `BuildAll` being publicly exposed since `IBuilder` declares all variants. Refactoring `IBuilder` to contain fewer methods and expose convenience methods via extensions methods is out of scope.~~
Register `ServiceProviderAdapter` as `IBuilder` to make use of that when creating custom implementations.

## Example
```c#
namespace ConsoleApp1
{
    using System;
    using System.Threading;
    using System.Threading.Tasks;
    using Microsoft.Extensions.DependencyInjection;
    using Microsoft.Extensions.Hosting;
    using Microsoft.Extensions.Logging;
    using NServiceBus;
    using NServiceBus.Extensions.Hosting;
    using NServiceBus.ObjectBuilder;

    class Program
    {
        static async Task Main(string[] args)
        {
            await Host.CreateDefaultBuilder()
                .ConfigureServices(services => services.AddSingleton<EndpointInstanceStarter>())
                .UseNServiceBus<EndpointInstanceStarter>(context =>
                {
                    var endpoint = new EndpointConfiguration("Test");
                    endpoint.UseTransport<RabbitMQTransport>()
                        .ConnectionString("host=localhost")
                        .UseConventionalRoutingTopology();
                    return endpoint;
                })
                .RunConsoleAsync()
                .ConfigureAwait(false);
        }
    }

    sealed class EndpointInstanceStarter : IEndpointInstanceStarter
    {
        public EndpointInstanceStarter(
            ILoggerFactory loggerFactory,
            IStartableEndpointWithExternallyManagedContainer startableEndpoint,
            IBuilder builder)
        {
            this.loggerFactory = loggerFactory;
            this.startableEndpoint = startableEndpoint;
            this.builder = builder;
        }

        /// <inheritdoc />
        public async Task<IStoppableEndpoint> Start()
        {
            var retry = new EndpointStarterRetry(
                loggerFactory.CreateLogger<EndpointStarterRetry>(),
                Starter);
            try
            {
                await retry.Start().ConfigureAwait(false);
            }
            catch (OperationCanceledException)
            {
                // Cancelled
            }
            return retry;
        }

        async Task<IEndpointInstance> Starter()
        {
            return await startableEndpoint.Start(builder);
        }

        readonly ILoggerFactory loggerFactory;
        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
        readonly IBuilder builder;

        sealed class EndpointStarterRetry : IStoppableEndpoint
        {
            public delegate Task<IEndpointInstance> EndpointStarter();

            public EndpointStarterRetry(
                ILogger<EndpointStarterRetry> logger,
                EndpointStarter starter)
            {
                this.logger = logger;
                this.starter = starter;
                timer = new Timer(Start);
            }

            /// <inheritdoc />
            public Task Stop()
            {
                timer.Dispose();
                return endpoint?.Stop() ?? Task.CompletedTask;
            }

            internal async Task Start()
            {
                try
                {
                    endpoint = await starter().ConfigureAwait(false);
                }
                catch
                {
                    ++retryCount;
                    logger.LogError("Retry count {RetryCount}, back off {BackOff} ms", retryCount, backOff.TotalMilliseconds);
                    timer.Change((int)backOff.TotalMilliseconds, -1);
                    backOff *= 2;
                }
            }

            async void Start(object state)
            {
                await Start().ConfigureAwait(false);
            }

            readonly ILogger<EndpointStarterRetry> logger;
            readonly EndpointStarter starter;
            readonly Timer timer;

            int retryCount;
            TimeSpan backOff = TimeSpan.FromMilliseconds(500);
            IEndpointInstance endpoint;
        }
    }
}
```