### PR TITLE
First class logging integration for Microsoft.Extensions.Logging

### DIFF
--- a/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
@@ -1,0 +1,273 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Collections.Concurrent;
+    using Logging;
+    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+    class DeferredLogger :
+        ILog
+    {
+        public DeferredLogger(string name)
+        {
+            this.name = name;
+        }
+
+        // capturing everything just in case when the logger is not yet set
+        public bool IsDebugEnabled => logger == null || logger.IsDebugEnabled;
+        public bool IsInfoEnabled => logger == null || logger.IsInfoEnabled;
+        public bool IsWarnEnabled => logger == null || logger.IsWarnEnabled;
+        public bool IsErrorEnabled => logger == null || logger.IsErrorEnabled;
+        public bool IsFatalEnabled => logger == null || logger.IsFatalEnabled;
+
+        public void Debug(string message)
+        {
+            if (logger != null)
+            {
+                logger.Debug(message);
+                return;
+            }
+
+            deferredMessageLogs.Enqueue((LogLevel.Debug, message));
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            if (logger != null)
+            {
+                logger.Debug(message, exception);
+                return;
+            }
+
+            deferredExceptionLogs.Enqueue((LogLevel.Debug, message, exception));
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            if (logger != null)
+            {
+                logger.DebugFormat(format, args);
+                return;
+            }
+
+            deferredFormatLogs.Enqueue((LogLevel.Debug, format, args));
+        }
+
+        public void Info(string message)
+        {
+            if (logger != null)
+            {
+                logger.Info(message);
+                return;
+            }
+
+            deferredMessageLogs.Enqueue((LogLevel.Info, message));
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            if (logger != null)
+            {
+                logger.Info(message, exception);
+                return;
+            }
+
+            deferredExceptionLogs.Enqueue((LogLevel.Info, message, exception));
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            if (logger != null)
+            {
+                logger.InfoFormat(format, args);
+                return;
+            }
+
+            deferredFormatLogs.Enqueue((LogLevel.Info, format, args));
+        }
+
+        public void Warn(string message)
+        {
+            if (logger != null)
+            {
+                logger.Warn(message);
+                return;
+            }
+
+            deferredMessageLogs.Enqueue((LogLevel.Warn, message));
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            if (logger != null)
+            {
+                logger.Warn(message, exception);
+                return;
+            }
+
+            deferredExceptionLogs.Enqueue((LogLevel.Warn, message, exception));
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            if (logger != null)
+            {
+                logger.WarnFormat(format, args);
+                return;
+            }
+
+            deferredFormatLogs.Enqueue((LogLevel.Warn, format, args));
+        }
+
+        public void Error(string message)
+        {
+            if (logger != null)
+            {
+                logger.Error(message);
+                return;
+            }
+
+            deferredMessageLogs.Enqueue((LogLevel.Error, message));
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            if (logger != null)
+            {
+                logger.Error(message, exception);
+                return;
+            }
+
+            deferredExceptionLogs.Enqueue((LogLevel.Error, message, exception));
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            if (logger != null)
+            {
+                logger.ErrorFormat(format, args);
+                return;
+            }
+
+            deferredFormatLogs.Enqueue((LogLevel.Error, format, args));
+        }
+
+        public void Fatal(string message)
+        {
+            if (logger != null)
+            {
+                logger.Fatal(message);
+                return;
+            }
+
+            deferredMessageLogs.Enqueue((LogLevel.Fatal, message));
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            if (logger != null)
+            {
+                logger.Fatal(message, exception);
+                return;
+            }
+
+            deferredExceptionLogs.Enqueue((LogLevel.Fatal, message, exception));
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            if (logger != null)
+            {
+                logger.FatalFormat(format, args);
+                return;
+            }
+
+            deferredFormatLogs.Enqueue((LogLevel.Fatal, format, args));
+        }
+
+        public void Flush(ILoggerFactory loggerFactory)
+        {
+            logger = new Logger(loggerFactory.CreateLogger(name));
+
+            while (deferredMessageLogs.TryDequeue(out var entry))
+            {
+                switch (entry.level)
+                {
+                    case LogLevel.Debug:
+                        logger.Debug(entry.message);
+                        break;
+                    case LogLevel.Info:
+                        logger.Info(entry.message);
+                        break;
+                    case LogLevel.Warn:
+                        logger.Warn(entry.message);
+                        break;
+                    case LogLevel.Error:
+                        logger.Error(entry.message);
+                        break;
+                    case LogLevel.Fatal:
+                        logger.Fatal(entry.message);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            while (deferredExceptionLogs.TryDequeue(out var entry))
+            {
+                switch (entry.level)
+                {
+                    case LogLevel.Debug:
+                        logger.Debug(entry.message, entry.exception);
+                        break;
+                    case LogLevel.Info:
+                        logger.Info(entry.message, entry.exception);
+                        break;
+                    case LogLevel.Warn:
+                        logger.Warn(entry.message, entry.exception);
+                        break;
+                    case LogLevel.Error:
+                        logger.Error(entry.message, entry.exception);
+                        break;
+                    case LogLevel.Fatal:
+                        logger.Fatal(entry.message, entry.exception);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            
+            while (deferredFormatLogs.TryDequeue(out var entry))
+            {
+                switch (entry.level)
+                {
+                    case LogLevel.Debug:
+                        logger.DebugFormat(entry.format, entry.args);
+                        break;
+                    case LogLevel.Info:
+                        logger.InfoFormat(entry.format, entry.args);
+                        break;
+                    case LogLevel.Warn:
+                        logger.WarnFormat(entry.format, entry.args);
+                        break;
+                    case LogLevel.Error:
+                        logger.ErrorFormat(entry.format, entry.args);
+                        break;
+                    case LogLevel.Fatal:
+                        logger.FatalFormat(entry.format, entry.args);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        readonly ConcurrentQueue<(LogLevel level, string message)> deferredMessageLogs = new ConcurrentQueue<(LogLevel level, string message)>();
+        readonly ConcurrentQueue<(LogLevel level, string message, Exception exception)> deferredExceptionLogs = new ConcurrentQueue<(LogLevel level, string message, Exception exception)>();
+        readonly ConcurrentQueue<(LogLevel level, string format, object[] args)> deferredFormatLogs = new ConcurrentQueue<(LogLevel level, string format, object[] args)>();
+
+        string name;
+
+        ILog logger;
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/Logging/DeferredLoggerFactory.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/DeferredLoggerFactory.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Collections.Concurrent;
+    using Logging;
+
+    class DeferredLoggerFactory :
+        ILoggerFactory
+    {
+        private readonly ConcurrentBag<DeferredLogger> acquiredLoggers = new ConcurrentBag<DeferredLogger>();
+
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            var deferredLogger = new DeferredLogger(name);
+            acquiredLoggers.Add(deferredLogger);
+            return deferredLogger;
+        }
+
+        public void FlushAll(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
+        {
+            while (acquiredLoggers.TryTake(out var logger))
+            {
+                logger.Flush(loggerFactory);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using Logging;
+    using Microsoft.Extensions.Logging;
+    using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+    class Logger : ILog
+    {
+        public Logger(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
+
+        public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
+
+        public bool IsWarnEnabled => logger.IsEnabled(LogLevel.Warning);
+
+        public bool IsErrorEnabled => logger.IsEnabled(LogLevel.Error);
+
+        public bool IsFatalEnabled => logger.IsEnabled(LogLevel.Critical);
+
+        public void Debug(string message)
+        {
+            logger.LogDebug(message);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            logger.LogDebug(exception, message);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            logger.LogDebug(format, args);
+        }
+
+        public void Info(string message)
+        {
+            logger.LogInformation(message);
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            logger.LogInformation(exception, message);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            logger.LogInformation(format, args);
+        }
+
+        public void Warn(string message)
+        {
+            logger.LogWarning(message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            logger.LogWarning(exception, message);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            logger.LogWarning(format, args);
+        }
+
+        public void Error(string message)
+        {
+            logger.LogError(message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            logger.LogError(exception, message);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            logger.LogError(format, args);
+        }
+
+        public void Fatal(string message)
+        {
+            logger.LogCritical(message);
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            logger.LogCritical(exception, message);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            logger.LogCritical(format, args);
+        }
+
+        ILogger logger;
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using Logging;
+    using IMsLoggingFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+    class LoggerFactory : ILoggerFactory
+    {
+        public LoggerFactory(IMsLoggingFactory loggerFactory)
+        {
+            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        public ILog GetLogger(Type type) => new Logger(loggerFactory.CreateLogger(type.FullName));
+
+        public ILog GetLogger(string name) => new Logger(loggerFactory.CreateLogger(name));
+
+        IMsLoggingFactory loggerFactory;
+    }
+}


### PR DESCRIPTION
Closes #46

- Registers a deferred factory as soon as NServiceBus usage is indicated to intercept log statements created when DI is not yet available
- Early created loggers need to take into account log levels configured on MS DI once it is available and therefore early on indicate `true` on all log levels and later on forward to MS logger
