### PR TITLE
Check that UseNServiceBus is only used once on the same host

### DIFF
--- a/src/AcceptanceTests/When_started_up.cs
+++ b/src/AcceptanceTests/When_started_up.cs
@@ -1,10 +1,10 @@
 ﻿namespace AcceptanceTests
 {
-    using Microsoft.Extensions.Hosting;
-    using NUnit.Framework;
-    using NServiceBus;
-    using Microsoft.Extensions.DependencyInjection;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
 
     [TestFixture]
     public class When_started_up
@@ -22,11 +22,16 @@
                 })
                 .Build();
 
-            await host.StartAsync();
+            try
+            {
+                await host.StartAsync();
 
-            Assert.NotNull(host.Services.GetService<IMessageSession>());
-
-            await host.StopAsync();
+                Assert.NotNull(host.Services.GetService<IMessageSession>());
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
         }
     }
 }

--- a/src/AcceptanceTests/When_used_multiple_times.cs
+++ b/src/AcceptanceTests/When_used_multiple_times.cs
@@ -1,0 +1,35 @@
+﻿namespace AcceptanceTests
+{
+    using System;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_used_multiple_times
+    {
+        [Test]
+        public void Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                Host.CreateDefaultBuilder()
+                    .UseNServiceBus(hostBuilderContext =>
+                    {
+                        var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+                        endpointConfiguration.SendOnly();
+                        endpointConfiguration.UseTransport<LearningTransport>();
+                        return endpointConfiguration;
+                    })
+                    .UseNServiceBus(hostBuilderContext =>
+                    {
+                        var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+                        endpointConfiguration.SendOnly();
+                        endpointConfiguration.UseTransport<LearningTransport>();
+                        return endpointConfiguration;
+                    })
+                    .Build();
+            });
+        }
+    }
+}

--- a/src/AcceptanceTests/When_used_multiple_times.cs
+++ b/src/AcceptanceTests/When_used_multiple_times.cs
@@ -9,7 +9,7 @@
     public class When_used_multiple_times
     {
         [Test]
-        public void Throws()
+        public void Throws_on_same_host()
         {
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -23,7 +23,34 @@
                     })
                     .UseNServiceBus(hostBuilderContext =>
                     {
-                        var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+                        var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
+                        endpointConfiguration.SendOnly();
+                        endpointConfiguration.UseTransport<LearningTransport>();
+                        return endpointConfiguration;
+                    })
+                    .Build();
+            });
+        }
+
+        [Test]
+        public void Does_not_throw_on_different_hosts()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                Host.CreateDefaultBuilder()
+                    .UseNServiceBus(hostBuilderContext =>
+                    {
+                        var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
+                        endpointConfiguration.SendOnly();
+                        endpointConfiguration.UseTransport<LearningTransport>();
+                        return endpointConfiguration;
+                    })
+                    .Build();
+
+                Host.CreateDefaultBuilder()
+                    .UseNServiceBus(hostBuilderContext =>
+                    {
+                        var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
                         endpointConfiguration.SendOnly();
                         endpointConfiguration.UseTransport<LearningTransport>();
                         return endpointConfiguration;

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -32,7 +32,8 @@
                     x.ImplementationFactory.Method.ReturnType == typeof(NServiceBusHostedService) &&
                     x.Lifetime == ServiceLifetime.Singleton))
                 {
-                    throw new InvalidOperationException("TODO");
+                    throw new InvalidOperationException(
+                        "`UseNServiceBus` can only be used once on the same host instance because subsequent calls would override each other. For multi-endpoint hosting scenarios consult our documentation page.");
                 }
 
                 serviceCollection.AddSingleton(_ => startableEndpoint.MessageSession.Value);


### PR DESCRIPTION
Verifies that `UseNServiceBus` can only be used once-only on the same host. The rational is that if you use it multiple times on the same host subsequent calls will silently override the service collection bindings of the previous calls leading to unnecessary confusing. `UseNServiceBus` is not suitable for multi-endpoint hosting.