### PR TITLE
[Spike] Installer support

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-rc.3" />
+    <PackageReference Include="NServiceBus" Version="8.1.0-alpha.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Extensions.Hosting.Tests/NServiceBus.Extensions.Hosting.Tests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.Tests/NServiceBus.Extensions.Hosting.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-rc.3" />
+    <PackageReference Include="NServiceBus" Version="8.1.0-alpha.0.16" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
   </ItemGroup>

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -2,8 +2,11 @@
 {
     using System;
     using Extensions.Hosting;
+    using Installation;
     using Logging;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Hosting;
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
@@ -31,16 +34,38 @@
                 ctx.Properties.Add(HostBuilderExtensionInUse, null);
 
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
-                var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection);
 
-                serviceCollection.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));
-                serviceCollection.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetService<HostAwareMessageSession>());
-                serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(
-                    startableEndpoint,
-                    serviceProvider,
-                    serviceProvider.GetRequiredService<ILoggerFactory>(),
-                    deferredLoggerFactory,
-                    serviceProvider.GetRequiredService<HostAwareMessageSession>()));
+                if (ctx.Configuration.GetValue<string>("nservicebus") == "install")
+                {
+                    // clear out other hosted services that were registered before `UseNServiceBus`
+                    // Note that this won't affect hosted services registered afterwards
+                    serviceCollection.RemoveAll(typeof(IHostedService));
+
+                    var installer =
+                        Installer.CreateInstallerWithExternallyManagedContainer(endpointConfiguration,
+                            serviceCollection);
+                    serviceCollection.AddHostedService(serviceProvider =>
+                        new NServiceBusInstallerService(
+                            installer,
+                            serviceProvider.GetRequiredService<IHostApplicationLifetime>(),
+                            serviceProvider));
+
+                    // register a message session to allow dependencies to be resolved (e.g. in other hosted services)
+                    serviceCollection.AddSingleton<IMessageSession, InstallerMessageSession>();
+                }
+                else
+                {
+                    var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection);
+
+                    serviceCollection.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));
+                    serviceCollection.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetService<HostAwareMessageSession>());
+                    serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(
+                        startableEndpoint,
+                        serviceProvider,
+                        serviceProvider.GetRequiredService<ILoggerFactory>(),
+                        deferredLoggerFactory,
+                        serviceProvider.GetRequiredService<HostAwareMessageSession>()));
+                }
             });
 
             return hostBuilder;

--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="NServiceBus" Version="[8.0.0-rc.3, 9)" />
+    <PackageReference Include="NServiceBus" Version="8.1.0-alpha.0.16" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusInstallerService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusInstallerService.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.Extensions.Hosting
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Installation;
+    using Microsoft.Extensions.Hosting;
+
+    class NServiceBusInstallerService : IHostedService
+    {
+        IServiceProvider serviceProvider;
+        IHostApplicationLifetime applicationLifetime;
+        InstallerWithExternallyManagedContainer installer;
+
+        public NServiceBusInstallerService(InstallerWithExternallyManagedContainer installer, IHostApplicationLifetime applicationLifetime, IServiceProvider serviceProvider)
+        {
+            this.installer = installer;
+            this.applicationLifetime = applicationLifetime;
+            this.serviceProvider = serviceProvider;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            await installer.Run(serviceProvider, cancellationToken).ConfigureAwait(false);
+            // immediately stop the application
+            // This will continue to execute other installers but will update the cancellation token
+            applicationLifetime.StopApplication();
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+    class InstallerMessageSession : IMessageSession
+    {
+#pragma warning disable PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+        Task ThrowException() =>
+            throw new InvalidOperationException(
+                "Attempt to use the `IMessageSession` API while the endpoint runs in installation mode.");
+#pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+
+        public Task Send(object message, SendOptions sendOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+
+        public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+
+        public Task Publish(object message, PublishOptions publishOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+
+        public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+
+        public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+
+        public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions,
+            CancellationToken cancellationToken = new CancellationToken()) =>
+            ThrowException();
+    }
+}


### PR DESCRIPTION
this is connected to https://github.com/Particular/NServiceBus/pull/6543 to use the proposed installation APIs to change the generic host behavior to only install NServiceBus and immediately stopping the application again when passing in the installation option (e.g. via command line arguments).

This PR doesn't build because the necessary NServiceBus changes haven't been merged/released and requires a local build instead.

The approach replaces the default NServiceBus hosted service with a different one that only executes the installation APIs.

The main difficulty comes from dealing with other hosted services that are configured when using the generic host. This would be a custom hosted service to send messages at endpoint startup, some worker process or an asp.net web app. When starting up we wouldn't want those services to be executed. However, all services are still built from DI when running the host, so `IMessageSession` needs to be registered in DI. Additionally, all hosted services registered after `UseNServiceBus` (and most of them should be) are still started after the installation has completed. So they must be aware that the cancellation token passed to `Start` can be cancelled already and abort early to prevent unwanted side-effects during installation. ASP.NET seems to check the token fairly late for example, so it's not quite clear how that would impact installation behavior for web apps.