### PR TITLE
Always allow hosted service to be stopped

### DIFF
--- a/src/NServiceBus.Extensions.Hosting.Tests/NServiceBus.Extensions.Hosting.Tests.csproj
+++ b/src/NServiceBus.Extensions.Hosting.Tests/NServiceBus.Extensions.Hosting.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Extensions.Hosting.Tests/NServiceBusHostedServiceTests.cs
+++ b/src/NServiceBus.Extensions.Hosting.Tests/NServiceBusHostedServiceTests.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Extensions.Hosting.Tests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class NServiceBusHostedServiceTests
+    {
+        [Test]
+        public void When_stopping_without_starting_should_not_throw()
+        {
+            var hostedService = new NServiceBusHostedService(null, null, null, null, null);
+
+            Assert.DoesNotThrowAsync(async () => await hostedService.StopAsync());
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="NServiceBus.Extensions.Hosting.Tests" Key="$(NServiceBusTestsKey)" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -33,10 +33,8 @@
             hostAwareMessageSession.MarkReadyForUse();
         }
 
-        public Task StopAsync(CancellationToken cancellationToken = default)
-        {
-            return endpoint.Stop(cancellationToken);
-        }
+        public Task StopAsync(CancellationToken cancellationToken = default) =>
+            endpoint?.Stop(cancellationToken) ?? Task.CompletedTask;
 
         readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
         readonly IServiceProvider serviceProvider;


### PR DESCRIPTION
The current implementation assumes that the hosted service controlling the NServiceBus endpoint lifetime will never be stopped without being started. However, there are scenarios where this can happen. Since the generic host does not stop hosted services when `StartAsync` or `Run` fails, there might be reasons a user calls `host.StopAsync()` to ensure all started background tasks are cleaned up (e.g. when the process shouldn't be stopped due to a startup failure). If the failure was caused by a hosted service that runs before the `NServiceBusHostedService`, this would cause an NRE since the endpoint hasn't been set yet but stop will call stop on all hosted services, not just the already started ones.