### PR TITLE
Add UseNServiceBus to new .NET 8 IHostApplicationBuilder interface

### DIFF
--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1,6 +1,10 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Extensions.Hosting.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus
 {
+    public static class HostApplicationBuilderExtensions
+    {
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, System.Func<NServiceBus.EndpointConfiguration> configureEndpoint) { }
+    }
     public static class HostBuilderExtensions
     {
         public static Microsoft.Extensions.Hosting.IHostBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder, System.Func<Microsoft.Extensions.Hosting.HostBuilderContext, NServiceBus.EndpointConfiguration> endpointConfigurationBuilder) { }

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using Extensions.Hosting;
+    using Logging;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+    /// <summary>
+    /// Extension methods to configure NServiceBus for the .NET Core generic host.
+    /// </summary>
+    public static class HostApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the host to start an NServiceBus endpoint.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configureEndpoint"></param>
+        /// <returns></returns>
+        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<IHostApplicationBuilder, EndpointConfiguration> configureEndpoint)
+        {
+            var deferredLoggerFactory = new DeferredLoggerFactory();
+            LogManager.UseFactory(deferredLoggerFactory);
+
+            if (builder.Properties.ContainsKey(HostBuilderExtensionInUse))
+            {
+                throw new InvalidOperationException(
+                    "`UseNServiceBus` can only be used once on the same host instance because subsequent calls would override each other. For multi-endpoint hosting scenarios consult our documentation page.");
+            }
+
+            builder.Properties.Add(HostBuilderExtensionInUse, null);
+
+            var endpointConfiguration = configureEndpoint(builder);
+            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
+
+            builder.Services.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));
+            builder.Services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
+            builder.Services.AddHostedService(serviceProvider => new NServiceBusHostedService(
+                startableEndpoint,
+                serviceProvider,
+                serviceProvider.GetRequiredService<ILoggerFactory>(),
+                deferredLoggerFactory,
+                serviceProvider.GetRequiredService<HostAwareMessageSession>()));
+
+            return builder;
+        }
+
+        const string HostBuilderExtensionInUse = "NServiceBus.Extension.Hosting.UseNServiceBus";
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@
         /// <param name="builder"></param>
         /// <param name="configureEndpoint"></param>
         /// <returns></returns>
-        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<IHostApplicationBuilder, EndpointConfiguration> configureEndpoint)
+        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<EndpointConfiguration> configureEndpoint)
         {
             var deferredLoggerFactory = new DeferredLoggerFactory();
             LogManager.UseFactory(deferredLoggerFactory);
@@ -31,7 +31,7 @@
 
             builder.Properties.Add(HostBuilderExtensionInUse, null);
 
-            var endpointConfiguration = configureEndpoint(builder);
+            var endpointConfiguration = configureEndpoint();
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
 
             builder.Services.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));


### PR DESCRIPTION
Fixes #429 

Add new extension method for adding NServiceBus to the new .NET 8 Generic host builder approach

Works for WebApplication.CreateBuilder and Host.CreateApplicationBuilder.