### PR TITLE
IHostApplicationBuilder follow-up changes

### DIFF
--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
@@ -1,30 +1,34 @@
 ﻿namespace AcceptanceTests
 {
-    using Microsoft.Extensions.Hosting;
-    using NUnit.Framework;
-    using NServiceBus;
-    using Microsoft.Extensions.DependencyInjection;
-    using System.Threading.Tasks;
-    using System.Threading;
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
 
     [TestFixture]
-    public class When_session_is_accessed_in_hosted_service_ctor
+    public class When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder
     {
         [Test]
         public void Should_throw()
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                var host = Host.CreateDefaultBuilder()
-                .UseNServiceBus(hostBuilderContext =>
+                var hostBuilder = Host.CreateApplicationBuilder();
+
+                hostBuilder.UseNServiceBus(() =>
                 {
                     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                     endpointConfiguration.SendOnly();
                     endpointConfiguration.UseTransport(new LearningTransport());
                     return endpointConfiguration;
-                })
-                .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInCtor>()).Build();
+                });
+
+                hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInCtor>();
+
+                var host = hostBuilder.Build();
 
                 await host.StartAsync();
             });

--- a/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
@@ -1,0 +1,67 @@
+﻿namespace AcceptanceTests
+{
+    using System;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_used_multiple_times_with_host_application_builder
+    {
+        [Test]
+        public void Throws_on_same_host()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var hostBuilder = Host.CreateApplicationBuilder();
+
+                hostBuilder.UseNServiceBus(() =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                });
+
+                hostBuilder.UseNServiceBus(() =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                });
+
+                hostBuilder.Build();
+            });
+        }
+
+        [Test]
+        public void Does_not_throw_on_different_hosts()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var hostBuilder1 = Host.CreateApplicationBuilder();
+                hostBuilder1.UseNServiceBus(() =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                });
+
+                hostBuilder1.Build();
+
+                var hostBuilder2 = Host.CreateApplicationBuilder();
+                hostBuilder2.UseNServiceBus(() =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                });
+
+                hostBuilder2.Build();
+            });
+        }
+    }
+}

--- a/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
@@ -1,0 +1,92 @@
+﻿namespace AcceptanceTests
+{
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using NServiceBus;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+    using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+    [TestFixture]
+    public class When_logging_with_host_builder
+    {
+        [Test]
+        public async Task Should_integrate_with_default_host_logging()
+        {
+            var builder = new StringBuilder();
+
+            var ExpectedLogMessage = "We want to see this";
+            var NotExpectedLogMessage = "We don't want to see this";
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.SetMinimumLevel(LogLevel.Warning);
+                    logging.AddProvider(new StringBuilderProvider(builder));
+                })
+                .UseNServiceBus(hostBuilderContext =>
+                {
+                    var logger = LogManager.GetLogger("TestLogger");
+                    logger.Warn(ExpectedLogMessage);
+                    logger.Debug(NotExpectedLogMessage);
+
+                    var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+                    endpointConfiguration.UseTransport(new LearningTransport { StorageDirectory = TestContext.CurrentContext.TestDirectory });
+
+                    return endpointConfiguration;
+                })
+                .Build();
+
+            try
+            {
+                await host.StartAsync();
+
+                StringAssert.Contains(ExpectedLogMessage, builder.ToString());
+                StringAssert.DoesNotContain(NotExpectedLogMessage, builder.ToString());
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+
+        class StringBuilderProvider : ILoggerProvider, ILogger
+        {
+            public StringBuilderProvider(StringBuilder builder)
+            {
+                this.builder = builder;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                var message = formatter(state, exception);
+                builder.AppendLine($"[{logLevel}] {message}");
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return this;
+            }
+
+            readonly StringBuilder builder;
+        }
+    }
+}

--- a/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_builder.cs
@@ -1,0 +1,57 @@
+﻿namespace AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_session_is_accessed_in_hosted_service_ctor_with_host_builder
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var host = Host.CreateDefaultBuilder()
+                .UseNServiceBus(hostBuilderContext =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                })
+                .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInCtor>()).Build();
+
+                await host.StartAsync();
+            });
+
+            StringAssert.Contains("The message session can't be used before NServiceBus is started", ex.Message);
+        }
+
+        class HostedServiceThatAccessSessionInCtor : IHostedService
+        {
+            public HostedServiceThatAccessSessionInCtor(IMessageSession messageSession)
+            {
+                messageSession.Publish<MyEvent>().GetAwaiter().GetResult();
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            class MyEvent : IEvent
+            {
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_start_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_start_with_host_builder.cs
@@ -1,0 +1,77 @@
+﻿namespace AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_session_is_accessed_in_hosted_service_start_with_host_builder
+    {
+        [Test]
+        public async Task Should_be_available_when_configured_after_NServiceBus()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .UseNServiceBus(hostBuilderContext =>
+                {
+                    var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+                    endpointConfiguration.SendOnly();
+                    endpointConfiguration.UseTransport(new LearningTransport());
+                    return endpointConfiguration;
+                })
+                .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInStart>())
+                .Build();
+
+            await host.StartAsync();
+            await host.StopAsync();
+        }
+
+        [Test]
+        public void Should_throw_when_hosted_service_is_configured_before_NServiceBus()
+        {
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var host = Host.CreateDefaultBuilder()
+                .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInStart>())
+                .UseNServiceBus(hostBuilderContext =>
+                  {
+                      var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+                      endpointConfiguration.SendOnly();
+                      endpointConfiguration.UseTransport(new LearningTransport());
+                      return endpointConfiguration;
+                  })
+                .Build();
+
+                await host.StartAsync();
+            });
+
+            StringAssert.Contains("The message session can't be used before NServiceBus is started", ex.Message);
+        }
+
+        class HostedServiceThatAccessSessionInStart : IHostedService
+        {
+            public HostedServiceThatAccessSessionInStart(IMessageSession messageSession)
+            {
+                this.messageSession = messageSession;
+            }
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                return messageSession.Publish<MyEvent>(cancellationToken);
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            class MyEvent : IEvent
+            {
+            }
+
+            readonly IMessageSession messageSession;
+        }
+    }
+}

--- a/src/AcceptanceTests/HostBuilder/When_used_multiple_times_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_used_multiple_times_with_host_builder.cs
@@ -6,7 +6,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_used_multiple_times
+    public class When_used_multiple_times_with_host_builder
     {
         [Test]
         public void Throws_on_same_host()

--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3,7 +3,7 @@ namespace NServiceBus
 {
     public static class HostApplicationBuilderExtensions
     {
-        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, System.Func<NServiceBus.EndpointConfiguration> configureEndpoint) { }
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, System.Func<NServiceBus.EndpointConfiguration> endpointConfigurationBuilder) { }
     }
     public static class HostBuilderExtensions
     {

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -8,17 +8,15 @@
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>
-    /// Extension methods to configure NServiceBus for the .NET Core generic host.
+    /// Extension methods to configure NServiceBus for the .NET hosted applications builder.
     /// </summary>
     public static class HostApplicationBuilderExtensions
     {
         /// <summary>
-        /// Configures the host to start an NServiceBus endpoint.
+        /// Configures the host application builder to start an NServiceBus endpoint.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="configureEndpoint"></param>
         /// <returns></returns>
-        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<EndpointConfiguration> configureEndpoint)
+        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<EndpointConfiguration> endpointConfigurationBuilder)
         {
             var deferredLoggerFactory = new DeferredLoggerFactory();
             LogManager.UseFactory(deferredLoggerFactory);
@@ -31,7 +29,7 @@
 
             builder.Properties.Add(HostBuilderExtensionInUse, null);
 
-            var endpointConfiguration = configureEndpoint();
+            var endpointConfiguration = endpointConfigurationBuilder();
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
 
             builder.Services.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -8,7 +8,7 @@
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>
-    /// Extension methods to configure NServiceBus for the .NET Core generic host.
+    /// Extension methods to configure NServiceBus for the .NET generic host.
     /// </summary>
     public static class HostBuilderExtensions
     {

--- a/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBus.Extensions.Hosting.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Description>Easy integration with Microsoft.Extensions.Hosting for NServiceBus</Description>
+    <Description>Integration with Microsoft.Extensions.Hosting for NServiceBus</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to #430 

This PR updates some descriptions and names, and also adds copies of all the existing tests for the new `IHostApplicationBuilder` version of `UseNServiceBus`.