### PR TITLE
More IHostApplicationBuilder changes

### DIFF
--- a/src/AcceptanceTests/HostApplicationBuilder/When_logging_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_logging_with_host_application_builder.cs
@@ -28,6 +28,7 @@
 
             var endpointConfiguration = new EndpointConfiguration("NSBRepro");
             endpointConfiguration.UseTransport(new LearningTransport { StorageDirectory = TestContext.CurrentContext.TestDirectory });
+            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
             hostBuilder.UseNServiceBus(endpointConfiguration);
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_logging_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_logging_with_host_application_builder.cs
@@ -26,17 +26,14 @@
             hostBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
             hostBuilder.Logging.AddProvider(new StringBuilderProvider(builder));
 
-            hostBuilder.UseNServiceBus(() =>
-            {
-                var logger = LogManager.GetLogger("TestLogger");
-                logger.Warn(ExpectedLogMessage);
-                logger.Debug(NotExpectedLogMessage);
+            var endpointConfiguration = new EndpointConfiguration("NSBRepro");
+            endpointConfiguration.UseTransport(new LearningTransport { StorageDirectory = TestContext.CurrentContext.TestDirectory });
 
-                var endpointConfiguration = new EndpointConfiguration("NSBRepro");
-                endpointConfiguration.UseTransport(new LearningTransport { StorageDirectory = TestContext.CurrentContext.TestDirectory });
+            hostBuilder.UseNServiceBus(endpointConfiguration);
 
-                return endpointConfiguration;
-            });
+            var logger = LogManager.GetLogger("TestLogger");
+            logger.Warn(ExpectedLogMessage);
+            logger.Debug(NotExpectedLogMessage);
 
             var host = hostBuilder.Build();
 
@@ -44,8 +41,9 @@
             {
                 await host.StartAsync();
 
-                StringAssert.Contains(ExpectedLogMessage, builder.ToString());
-                StringAssert.DoesNotContain(NotExpectedLogMessage, builder.ToString());
+                var actual = builder.ToString();
+                StringAssert.Contains(ExpectedLogMessage, actual);
+                StringAssert.DoesNotContain(NotExpectedLogMessage, actual);
             }
             finally
             {

--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
@@ -18,13 +18,11 @@
             {
                 var hostBuilder = Host.CreateApplicationBuilder();
 
-                hostBuilder.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+                endpointConfiguration.SendOnly();
+                endpointConfiguration.UseTransport(new LearningTransport());
+
+                hostBuilder.UseNServiceBus(endpointConfiguration);
 
                 hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInCtor>();
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_application_builder..cs
@@ -21,6 +21,7 @@
                 var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                 endpointConfiguration.SendOnly();
                 endpointConfiguration.UseTransport(new LearningTransport());
+                endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder.UseNServiceBus(endpointConfiguration);
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_start_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_start_with_host_application_builder.cs
@@ -19,6 +19,7 @@
             var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
             endpointConfiguration.SendOnly();
             endpointConfiguration.UseTransport(new LearningTransport());
+            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
             hostBuilder.UseNServiceBus(endpointConfiguration);
 
@@ -40,6 +41,7 @@
                 var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                 endpointConfiguration.SendOnly();
                 endpointConfiguration.UseTransport(new LearningTransport());
+                endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder.UseNServiceBus(endpointConfiguration);
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_start_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_hosted_service_start_with_host_application_builder.cs
@@ -15,13 +15,12 @@
         public async Task Should_be_available_when_configured_after_NServiceBus()
         {
             var hostBuilder = Host.CreateApplicationBuilder();
-            hostBuilder.UseNServiceBus(() =>
-            {
-                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
-                endpointConfiguration.SendOnly();
-                endpointConfiguration.UseTransport(new LearningTransport());
-                return endpointConfiguration;
-            });
+
+            var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+            endpointConfiguration.SendOnly();
+            endpointConfiguration.UseTransport(new LearningTransport());
+
+            hostBuilder.UseNServiceBus(endpointConfiguration);
 
             hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInStart>();
 
@@ -38,13 +37,11 @@
                 var hostBuilder = Host.CreateApplicationBuilder();
                 hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInStart>();
 
-                hostBuilder.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+                endpointConfiguration.SendOnly();
+                endpointConfiguration.UseTransport(new LearningTransport());
+
+                hostBuilder.UseNServiceBus(endpointConfiguration);
 
                 var host = hostBuilder.Build();
                 await host.StartAsync();

--- a/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
@@ -18,12 +18,14 @@
                 var endpointConfiguration1 = new EndpointConfiguration("NSBRepro");
                 endpointConfiguration1.SendOnly();
                 endpointConfiguration1.UseTransport(new LearningTransport());
+                endpointConfiguration1.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder.UseNServiceBus(endpointConfiguration1);
 
                 var endpointConfiguration2 = new EndpointConfiguration("NSBRepro1");
                 endpointConfiguration2.SendOnly();
                 endpointConfiguration2.UseTransport(new LearningTransport());
+                endpointConfiguration2.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder.UseNServiceBus(endpointConfiguration2);
 
@@ -41,6 +43,7 @@
                 var endpointConfiguration1 = new EndpointConfiguration("NSBRepro1");
                 endpointConfiguration1.SendOnly();
                 endpointConfiguration1.UseTransport(new LearningTransport());
+                endpointConfiguration1.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder1.UseNServiceBus(endpointConfiguration1);
 
@@ -51,6 +54,7 @@
                 var endpointConfiguration2 = new EndpointConfiguration("NSBRepro1");
                 endpointConfiguration2.SendOnly();
                 endpointConfiguration2.UseTransport(new LearningTransport());
+                endpointConfiguration2.UseSerialization<SystemJsonSerializer>();
 
                 hostBuilder2.UseNServiceBus(endpointConfiguration2);
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_used_multiple_times_with_host_application_builder.cs
@@ -15,21 +15,17 @@
             {
                 var hostBuilder = Host.CreateApplicationBuilder();
 
-                hostBuilder.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("NSBRepro");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+                var endpointConfiguration1 = new EndpointConfiguration("NSBRepro");
+                endpointConfiguration1.SendOnly();
+                endpointConfiguration1.UseTransport(new LearningTransport());
 
-                hostBuilder.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+                hostBuilder.UseNServiceBus(endpointConfiguration1);
+
+                var endpointConfiguration2 = new EndpointConfiguration("NSBRepro1");
+                endpointConfiguration2.SendOnly();
+                endpointConfiguration2.UseTransport(new LearningTransport());
+
+                hostBuilder.UseNServiceBus(endpointConfiguration2);
 
                 hostBuilder.Build();
             });
@@ -41,24 +37,22 @@
             Assert.DoesNotThrow(() =>
             {
                 var hostBuilder1 = Host.CreateApplicationBuilder();
-                hostBuilder1.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+
+                var endpointConfiguration1 = new EndpointConfiguration("NSBRepro1");
+                endpointConfiguration1.SendOnly();
+                endpointConfiguration1.UseTransport(new LearningTransport());
+
+                hostBuilder1.UseNServiceBus(endpointConfiguration1);
 
                 hostBuilder1.Build();
 
                 var hostBuilder2 = Host.CreateApplicationBuilder();
-                hostBuilder2.UseNServiceBus(() =>
-                {
-                    var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
-                    endpointConfiguration.SendOnly();
-                    endpointConfiguration.UseTransport(new LearningTransport());
-                    return endpointConfiguration;
-                });
+
+                var endpointConfiguration2 = new EndpointConfiguration("NSBRepro1");
+                endpointConfiguration2.SendOnly();
+                endpointConfiguration2.UseTransport(new LearningTransport());
+
+                hostBuilder2.UseNServiceBus(endpointConfiguration2);
 
                 hostBuilder2.Build();
             });

--- a/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
@@ -36,6 +36,7 @@
 
                     var endpointConfiguration = new EndpointConfiguration("NSBRepro");
                     endpointConfiguration.UseTransport(new LearningTransport { StorageDirectory = TestContext.CurrentContext.TestDirectory });
+                    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
                     return endpointConfiguration;
                 })

--- a/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_logging_with_host_builder.cs
@@ -45,8 +45,9 @@
             {
                 await host.StartAsync();
 
-                StringAssert.Contains(ExpectedLogMessage, builder.ToString());
-                StringAssert.DoesNotContain(NotExpectedLogMessage, builder.ToString());
+                var actual = builder.ToString();
+                StringAssert.Contains(ExpectedLogMessage, actual);
+                StringAssert.DoesNotContain(NotExpectedLogMessage, actual);
             }
             finally
             {

--- a/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_ctor_with_host_builder.cs
@@ -22,6 +22,7 @@
                     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                     endpointConfiguration.SendOnly();
                     endpointConfiguration.UseTransport(new LearningTransport());
+                    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                     return endpointConfiguration;
                 })
                 .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInCtor>()).Build();

--- a/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_start_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_session_is_accessed_in_hosted_service_start_with_host_builder.cs
@@ -20,6 +20,7 @@
                     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                     endpointConfiguration.SendOnly();
                     endpointConfiguration.UseTransport(new LearningTransport());
+                    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                     return endpointConfiguration;
                 })
                 .ConfigureServices((ctx, serviceProvider) => serviceProvider.AddHostedService<HostedServiceThatAccessSessionInStart>())
@@ -41,6 +42,7 @@
                       var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                       endpointConfiguration.SendOnly();
                       endpointConfiguration.UseTransport(new LearningTransport());
+                      endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                       return endpointConfiguration;
                   })
                 .Build();

--- a/src/AcceptanceTests/HostBuilder/When_used_multiple_times_with_host_builder.cs
+++ b/src/AcceptanceTests/HostBuilder/When_used_multiple_times_with_host_builder.cs
@@ -19,6 +19,7 @@
                         var endpointConfiguration = new EndpointConfiguration("NSBRepro");
                         endpointConfiguration.SendOnly();
                         endpointConfiguration.UseTransport(new LearningTransport());
+                        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                         return endpointConfiguration;
                     })
                     .UseNServiceBus(hostBuilderContext =>
@@ -26,6 +27,7 @@
                         var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
                         endpointConfiguration.SendOnly();
                         endpointConfiguration.UseTransport(new LearningTransport());
+                        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                         return endpointConfiguration;
                     })
                     .Build();
@@ -43,6 +45,7 @@
                         var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
                         endpointConfiguration.SendOnly();
                         endpointConfiguration.UseTransport(new LearningTransport());
+                        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                         return endpointConfiguration;
                     })
                     .Build();
@@ -53,6 +56,7 @@
                         var endpointConfiguration = new EndpointConfiguration("NSBRepro1");
                         endpointConfiguration.SendOnly();
                         endpointConfiguration.UseTransport(new LearningTransport());
+                        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
                         return endpointConfiguration;
                     })
                     .Build();

--- a/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.Hosting.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3,7 +3,7 @@ namespace NServiceBus
 {
     public static class HostApplicationBuilderExtensions
     {
-        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, System.Func<NServiceBus.EndpointConfiguration> endpointConfigurationBuilder) { }
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder UseNServiceBus(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, NServiceBus.EndpointConfiguration endpointConfiguration) { }
     }
     public static class HostBuilderExtensions
     {

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@
     using Logging;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>
@@ -16,7 +17,7 @@
         /// Configures the host application builder to start an NServiceBus endpoint.
         /// </summary>
         /// <returns></returns>
-        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, Func<EndpointConfiguration> endpointConfigurationBuilder)
+        public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, EndpointConfiguration endpointConfiguration)
         {
             var deferredLoggerFactory = new DeferredLoggerFactory();
             LogManager.UseFactory(deferredLoggerFactory);
@@ -29,7 +30,6 @@
 
             builder.Properties.Add(HostBuilderExtensionInUse, null);
 
-            var endpointConfiguration = endpointConfigurationBuilder();
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
 
             builder.Services.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -5,6 +5,7 @@
     using Logging;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Logging;
     using Microsoft.Extensions.Hosting;
+
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     class NServiceBusHostedService : IHostedService


### PR DESCRIPTION
After seeing the new API in use while converting samples, it made sense to remove the endpointConfigurationBuilder Func and instead just accept an `EndpointConfiguration`.

This overall seems like a safe thing to do, though it does open up a potential hole around logging if something in the EndpointConfiguration APIs uses the NServiceBus logger. I'd like to think that's not something we need to worry about though?

