### PR TITLE
Support concurrency and better start behavior out of the box

### DIFF
--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_multiple_hosted_services_started_concurrently_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_multiple_hosted_services_started_concurrently_with_host_application_builder.cs
@@ -14,7 +14,11 @@
         public async Task Should_be_available_when_configured_after_NServiceBus()
         {
             var hostBuilder = Host.CreateApplicationBuilder();
-
+            hostBuilder.Services.Configure<HostOptions>(options =>
+            {
+                options.ServicesStartConcurrently = true;
+                options.ServicesStopConcurrently = true;
+            });
             var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
             endpointConfiguration.SendOnly();
             endpointConfiguration.UseTransport(new LearningTransport());
@@ -34,6 +38,12 @@
         public async Task Should_be_available_when_configured_before_NServiceBus()
         {
             var hostBuilder = Host.CreateApplicationBuilder();
+            hostBuilder.Services.Configure<HostOptions>(options =>
+            {
+                options.ServicesStartConcurrently = true;
+                options.ServicesStopConcurrently = true;
+            });
+
             hostBuilder.Services.AddHostedService<FirstHostedService>();
             hostBuilder.Services.AddHostedService<SecondHostedService>();
 

--- a/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_multiple_hosted_services_started_concurrently_with_host_application_builder.cs
+++ b/src/AcceptanceTests/HostApplicationBuilder/When_session_is_accessed_in_multiple_hosted_services_started_concurrently_with_host_application_builder.cs
@@ -8,7 +8,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_session_is_accessed_in_hosted_service_start_with_host_application_builder
+    public class When_session_is_accessed_in_multiple_hosted_services_started_concurrently_with_host_application_builder
     {
         [Test]
         public async Task Should_be_available_when_configured_after_NServiceBus()
@@ -22,7 +22,8 @@
 
             hostBuilder.UseNServiceBus(endpointConfiguration);
 
-            hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInStart>();
+            hostBuilder.Services.AddHostedService<FirstHostedService>();
+            hostBuilder.Services.AddHostedService<SecondHostedService>();
 
             var host = hostBuilder.Build();
             await host.StartAsync();
@@ -33,7 +34,8 @@
         public async Task Should_be_available_when_configured_before_NServiceBus()
         {
             var hostBuilder = Host.CreateApplicationBuilder();
-            hostBuilder.Services.AddHostedService<HostedServiceThatAccessSessionInStart>();
+            hostBuilder.Services.AddHostedService<FirstHostedService>();
+            hostBuilder.Services.AddHostedService<SecondHostedService>();
 
             var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
             endpointConfiguration.SendOnly();
@@ -46,15 +48,20 @@
             await host.StartAsync();
         }
 
-        class HostedServiceThatAccessSessionInStart(IMessageSession messageSession) : IHostedService
+        class FirstHostedService(IMessageSession messageSession) : IHostedService
         {
             public Task StartAsync(CancellationToken cancellationToken) => messageSession.Publish<MyEvent>(cancellationToken);
 
             public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-            class MyEvent : IEvent
-            {
-            }
         }
+
+        class SecondHostedService(IMessageSession messageSession) : IHostedService
+        {
+            public Task StartAsync(CancellationToken cancellationToken) => messageSession.Publish<MyEvent>(cancellationToken);
+
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        class MyEvent : IEvent;
     }
 }

--- a/src/NServiceBus.Extensions.Hosting.Tests/NServiceBusHostedServiceTests.cs
+++ b/src/NServiceBus.Extensions.Hosting.Tests/NServiceBusHostedServiceTests.cs
@@ -8,7 +8,7 @@
         [Test]
         public void When_stopping_without_starting_should_not_throw()
         {
-            var hostedService = new NServiceBusHostedService(null, null, null, null, null);
+            var hostedService = new NServiceBusHostedService(new EndpointStarter(null, null, null, null));
 
             Assert.DoesNotThrowAsync(async () => await hostedService.StopAsync());
         }

--- a/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Extensions.Hosting
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
+
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     class EndpointStarter(
@@ -31,8 +32,7 @@ namespace NServiceBus.Extensions.Hosting
                 LogManager.UseFactory(new LoggerFactory(loggerFactory));
                 deferredLoggerFactory.FlushAll(loggerFactory);
 
-                endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken)
-                    .ConfigureAwait(false);
+                endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken).ConfigureAwait(false);
 
                 return endpoint;
             }

--- a/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.Extensions.Hosting;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Logging;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+class EndpointStarter(
+    IStartableEndpointWithExternallyManagedContainer startableEndpoint,
+    IServiceProvider serviceProvider,
+    ILoggerFactory loggerFactory,
+    DeferredLoggerFactory deferredLoggerFactory)
+{
+    public async ValueTask<IEndpointInstance> GetOrStart(CancellationToken cancellationToken = default)
+    {
+        if (endpoint != null)
+        {
+            return endpoint;
+        }
+
+        await startSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (endpoint != null)
+            {
+                return endpoint;
+            }
+
+            LogManager.UseFactory(new LoggerFactory(loggerFactory));
+            deferredLoggerFactory.FlushAll(loggerFactory);
+
+            endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken)
+                .ConfigureAwait(false);
+
+            return endpoint;
+        }
+        finally
+        {
+            startSemaphore.Release();
+        }
+    }
+
+    readonly SemaphoreSlim startSemaphore = new(1, 1);
+
+    IEndpointInstance endpoint;
+}

--- a/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
+++ b/src/NServiceBus.Extensions.Hosting/EndpointStarter.cs
@@ -1,48 +1,49 @@
-namespace NServiceBus.Extensions.Hosting;
-
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Logging;
-using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
-
-class EndpointStarter(
-    IStartableEndpointWithExternallyManagedContainer startableEndpoint,
-    IServiceProvider serviceProvider,
-    ILoggerFactory loggerFactory,
-    DeferredLoggerFactory deferredLoggerFactory)
+namespace NServiceBus.Extensions.Hosting
 {
-    public async ValueTask<IEndpointInstance> GetOrStart(CancellationToken cancellationToken = default)
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Logging;
+    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+    class EndpointStarter(
+        IStartableEndpointWithExternallyManagedContainer startableEndpoint,
+        IServiceProvider serviceProvider,
+        ILoggerFactory loggerFactory,
+        DeferredLoggerFactory deferredLoggerFactory)
     {
-        if (endpoint != null)
-        {
-            return endpoint;
-        }
-
-        await startSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        public async ValueTask<IEndpointInstance> GetOrStart(CancellationToken cancellationToken = default)
         {
             if (endpoint != null)
             {
                 return endpoint;
             }
 
-            LogManager.UseFactory(new LoggerFactory(loggerFactory));
-            deferredLoggerFactory.FlushAll(loggerFactory);
+            await startSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-            endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                if (endpoint != null)
+                {
+                    return endpoint;
+                }
 
-            return endpoint;
+                LogManager.UseFactory(new LoggerFactory(loggerFactory));
+                deferredLoggerFactory.FlushAll(loggerFactory);
+
+                endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return endpoint;
+            }
+            finally
+            {
+                startSemaphore.Release();
+            }
         }
-        finally
-        {
-            startSemaphore.Release();
-        }
+
+        readonly SemaphoreSlim startSemaphore = new(1, 1);
+
+        IEndpointInstance endpoint;
     }
-
-    readonly SemaphoreSlim startSemaphore = new(1, 1);
-
-    IEndpointInstance endpoint;
 }

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -32,14 +32,14 @@
 
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
 
-            builder.Services.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));
-            builder.Services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
-            builder.Services.AddHostedService(serviceProvider => new NServiceBusHostedService(
+            builder.Services.AddSingleton(serviceProvider => new EndpointStarter(
                 startableEndpoint,
                 serviceProvider,
                 serviceProvider.GetRequiredService<ILoggerFactory>(),
-                deferredLoggerFactory,
-                serviceProvider.GetRequiredService<HostAwareMessageSession>()));
+                deferredLoggerFactory));
+            builder.Services.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
+            builder.Services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
+            builder.Services.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));
 
             return builder;
         }

--- a/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostApplicationBuilderExtensions.cs
@@ -1,12 +1,10 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using Extensions.Hosting;
     using Logging;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-
-    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>
     /// Extension methods to configure NServiceBus for the .NET hosted applications builder.
@@ -19,28 +17,16 @@
         /// <returns></returns>
         public static IHostApplicationBuilder UseNServiceBus(this IHostApplicationBuilder builder, EndpointConfiguration endpointConfiguration)
         {
-            var deferredLoggerFactory = new DeferredLoggerFactory();
-            LogManager.UseFactory(deferredLoggerFactory);
-
-            if (builder.Properties.ContainsKey(HostBuilderExtensionInUse))
+            if (!builder.Properties.TryAdd(HostBuilderExtensionInUse, null))
             {
                 throw new InvalidOperationException(
                     "`UseNServiceBus` can only be used once on the same host instance because subsequent calls would override each other. For multi-endpoint hosting scenarios consult our documentation page.");
             }
 
-            builder.Properties.Add(HostBuilderExtensionInUse, null);
+            var deferredLoggerFactory = new DeferredLoggerFactory();
+            LogManager.UseFactory(deferredLoggerFactory);
 
-            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, builder.Services);
-
-            builder.Services.AddSingleton(serviceProvider => new EndpointStarter(
-                startableEndpoint,
-                serviceProvider,
-                serviceProvider.GetRequiredService<ILoggerFactory>(),
-                deferredLoggerFactory));
-            builder.Services.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
-            builder.Services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
-            builder.Services.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));
-
+            builder.Services.AddNServiceBus(endpointConfiguration, deferredLoggerFactory);
             return builder;
         }
 

--- a/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
@@ -3,72 +3,50 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extensions.Hosting;
 
-    class HostAwareMessageSession : IMessageSession
+    class HostAwareMessageSession(EndpointStarter endpointStarter) : IMessageSession
     {
-        public HostAwareMessageSession(Lazy<IMessageSession> messageSession)
+        public async Task Send(object message, SendOptions options, CancellationToken cancellationToken = default)
         {
-            this.messageSession = messageSession;
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
+
+            await messageSession.Send(message, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Send(object message, SendOptions options, CancellationToken cancellationToken = default)
+        public async Task Send<T>(Action<T> messageConstructor, SendOptions options, CancellationToken cancellationToken = default)
         {
-            GuardAgainstTooEarlyUse();
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
-            return messageSession.Value.Send(message, options, cancellationToken);
+            await messageSession.Send(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Send<T>(Action<T> messageConstructor, SendOptions options, CancellationToken cancellationToken = default)
+        public async Task Publish(object message, PublishOptions options, CancellationToken cancellationToken = default)
         {
-            GuardAgainstTooEarlyUse();
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
-            return messageSession.Value.Send(messageConstructor, options, cancellationToken);
+            await messageSession.Publish(message, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Publish(object message, PublishOptions options, CancellationToken cancellationToken = default)
+        public async Task Publish<T>(Action<T> messageConstructor, PublishOptions options, CancellationToken cancellationToken = default)
         {
-            GuardAgainstTooEarlyUse();
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
-            return messageSession.Value.Publish(message, options, cancellationToken);
+            await messageSession.Publish(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Publish<T>(Action<T> messageConstructor, PublishOptions options, CancellationToken cancellationToken = default)
+        public async Task Subscribe(Type eventType, SubscribeOptions options, CancellationToken cancellationToken = default)
         {
-            GuardAgainstTooEarlyUse();
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
-            return messageSession.Value.Publish(messageConstructor, options, cancellationToken);
+            await messageSession.Subscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Subscribe(Type eventType, SubscribeOptions options, CancellationToken cancellationToken = default)
+        public async Task Unsubscribe(Type eventType, UnsubscribeOptions options, CancellationToken cancellationToken = default)
         {
-            GuardAgainstTooEarlyUse();
+            var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
-            return messageSession.Value.Subscribe(eventType, options, cancellationToken);
+            await messageSession.Unsubscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
-
-        public Task Unsubscribe(Type eventType, UnsubscribeOptions options, CancellationToken cancellationToken = default)
-        {
-            GuardAgainstTooEarlyUse();
-
-            return messageSession.Value.Unsubscribe(eventType, options, cancellationToken);
-        }
-
-        public void MarkReadyForUse()
-        {
-            isReadyForUse = true;
-        }
-
-        void GuardAgainstTooEarlyUse()
-        {
-            if (isReadyForUse)
-            {
-                return;
-            }
-
-            throw new InvalidOperationException("The message session can't be used before NServiceBus is started. Place `UseNServiceBus()` on the host builder before registering any hosted service (e.g. `services.AddHostedService<HostedServiceAccessingTheSession>()`) or the web host configuration (e.g. `builder.ConfigureWebHostDefaults`) should hosted services or controllers require access to the session.");
-        }
-
-        bool isReadyForUse;
-        Lazy<IMessageSession> messageSession;
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
@@ -1,9 +1,8 @@
-﻿namespace NServiceBus
+﻿namespace NServiceBus.Extensions.Hosting
 {
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Extensions.Hosting;
 
     class HostAwareMessageSession(EndpointStarter endpointStarter) : IMessageSession
     {

--- a/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostAwareMessageSession.cs
@@ -9,42 +9,36 @@
         public async Task Send(object message, SendOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Send(message, options, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Send<T>(Action<T> messageConstructor, SendOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Send(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Publish(object message, PublishOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Publish(message, options, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Publish<T>(Action<T> messageConstructor, PublishOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Publish(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Subscribe(Type eventType, SubscribeOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Subscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task Unsubscribe(Type eventType, UnsubscribeOptions options, CancellationToken cancellationToken = default)
         {
             var messageSession = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
-
             await messageSession.Unsubscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -1,12 +1,10 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using Extensions.Hosting;
     using Logging;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-
-    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     /// <summary>
     /// Extension methods to configure NServiceBus for the .NET generic host.
@@ -21,27 +19,16 @@
             var deferredLoggerFactory = new DeferredLoggerFactory();
             LogManager.UseFactory(deferredLoggerFactory);
 
-            hostBuilder.ConfigureServices((ctx, serviceCollection) =>
+            hostBuilder.ConfigureServices((ctx, services) =>
             {
-                if (ctx.Properties.ContainsKey(HostBuilderExtensionInUse))
+                if (!ctx.Properties.TryAdd(HostBuilderExtensionInUse, null))
                 {
                     throw new InvalidOperationException(
                         "`UseNServiceBus` can only be used once on the same host instance because subsequent calls would override each other. For multi-endpoint hosting scenarios consult our documentation page.");
                 }
 
-                ctx.Properties.Add(HostBuilderExtensionInUse, null);
-
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
-                var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection);
-
-                serviceCollection.AddSingleton(serviceProvider => new EndpointStarter(
-                    startableEndpoint,
-                    serviceProvider,
-                    serviceProvider.GetRequiredService<ILoggerFactory>(),
-                    deferredLoggerFactory));
-                serviceCollection.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
-                serviceCollection.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
-                serviceCollection.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));
+                services.AddNServiceBus(endpointConfiguration, deferredLoggerFactory);
             });
 
             return hostBuilder;

--- a/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/HostBuilderExtensions.cs
@@ -34,14 +34,14 @@
                 var endpointConfiguration = endpointConfigurationBuilder(ctx);
                 var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection);
 
-                serviceCollection.AddSingleton(_ => new HostAwareMessageSession(startableEndpoint.MessageSession));
-                serviceCollection.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetService<HostAwareMessageSession>());
-                serviceCollection.AddSingleton<IHostedService>(serviceProvider => new NServiceBusHostedService(
+                serviceCollection.AddSingleton(serviceProvider => new EndpointStarter(
                     startableEndpoint,
                     serviceProvider,
                     serviceProvider.GetRequiredService<ILoggerFactory>(),
-                    deferredLoggerFactory,
-                    serviceProvider.GetRequiredService<HostAwareMessageSession>()));
+                    deferredLoggerFactory));
+                serviceCollection.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
+                serviceCollection.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
+                serviceCollection.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));
             });
 
             return hostBuilder;

--- a/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
@@ -3,15 +3,20 @@
     using System;
     using System.Collections.Concurrent;
     using Logging;
+
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     class DeferredLogger(string name) : ILog
     {
         // capturing everything just in case when the logger is not yet set
         public bool IsDebugEnabled => logger == null || logger.IsDebugEnabled;
+
         public bool IsInfoEnabled => logger == null || logger.IsInfoEnabled;
+
         public bool IsWarnEnabled => logger == null || logger.IsWarnEnabled;
+
         public bool IsErrorEnabled => logger == null || logger.IsErrorEnabled;
+
         public bool IsFatalEnabled => logger == null || logger.IsFatalEnabled;
 
         public void Debug(string message)

--- a/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/DeferredLogger.cs
@@ -5,14 +5,8 @@
     using Logging;
     using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
-    class DeferredLogger :
-        ILog
+    class DeferredLogger(string name) : ILog
     {
-        public DeferredLogger(string name)
-        {
-            this.name = name;
-        }
-
         // capturing everything just in case when the logger is not yet set
         public bool IsDebugEnabled => logger == null || logger.IsDebugEnabled;
         public bool IsInfoEnabled => logger == null || logger.IsInfoEnabled;
@@ -262,11 +256,9 @@
             }
         }
 
-        readonly ConcurrentQueue<(LogLevel level, string message)> deferredMessageLogs = new ConcurrentQueue<(LogLevel level, string message)>();
-        readonly ConcurrentQueue<(LogLevel level, string message, Exception exception)> deferredExceptionLogs = new ConcurrentQueue<(LogLevel level, string message, Exception exception)>();
-        readonly ConcurrentQueue<(LogLevel level, string format, object[] args)> deferredFormatLogs = new ConcurrentQueue<(LogLevel level, string format, object[] args)>();
-
-        string name;
+        readonly ConcurrentQueue<(LogLevel level, string message)> deferredMessageLogs = new();
+        readonly ConcurrentQueue<(LogLevel level, string message, Exception exception)> deferredExceptionLogs = new();
+        readonly ConcurrentQueue<(LogLevel level, string format, object[] args)> deferredFormatLogs = new();
 
         ILog logger;
     }

--- a/src/NServiceBus.Extensions.Hosting/Logging/DeferredLoggerFactory.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/DeferredLoggerFactory.cs
@@ -4,15 +4,11 @@
     using System.Collections.Concurrent;
     using Logging;
 
-    class DeferredLoggerFactory :
-        ILoggerFactory
+    class DeferredLoggerFactory : ILoggerFactory
     {
         readonly ConcurrentBag<DeferredLogger> acquiredLoggers = [];
 
-        public ILog GetLogger(Type type)
-        {
-            return GetLogger(type.FullName);
-        }
+        public ILog GetLogger(Type type) => GetLogger(type.FullName);
 
         public ILog GetLogger(string name)
         {

--- a/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
@@ -5,13 +5,8 @@
     using Microsoft.Extensions.Logging;
     using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
-    class Logger : ILog
+    class Logger(ILogger logger) : ILog
     {
-        public Logger(ILogger logger)
-        {
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
         public bool IsDebugEnabled => logger.IsEnabled(LogLevel.Debug);
 
         public bool IsInfoEnabled => logger.IsEnabled(LogLevel.Information);
@@ -22,81 +17,36 @@
 
         public bool IsFatalEnabled => logger.IsEnabled(LogLevel.Critical);
 
-        public void Debug(string message)
-        {
-            logger.LogDebug(message);
-        }
+        public void Debug(string message) => logger.LogDebug(message);
 
-        public void Debug(string message, Exception exception)
-        {
-            logger.LogDebug(exception, message);
-        }
+        public void Debug(string message, Exception exception) => logger.LogDebug(exception, message);
 
-        public void DebugFormat(string format, params object[] args)
-        {
-            logger.LogDebug(format, args);
-        }
+        public void DebugFormat(string format, params object[] args) => logger.LogDebug(format, args);
 
-        public void Info(string message)
-        {
-            logger.LogInformation(message);
-        }
+        public void Info(string message) => logger.LogInformation(message);
 
-        public void Info(string message, Exception exception)
-        {
-            logger.LogInformation(exception, message);
-        }
+        public void Info(string message, Exception exception) => logger.LogInformation(exception, message);
 
-        public void InfoFormat(string format, params object[] args)
-        {
-            logger.LogInformation(format, args);
-        }
+        public void InfoFormat(string format, params object[] args) => logger.LogInformation(format, args);
 
-        public void Warn(string message)
-        {
-            logger.LogWarning(message);
-        }
+        public void Warn(string message) => logger.LogWarning(message);
 
-        public void Warn(string message, Exception exception)
-        {
-            logger.LogWarning(exception, message);
-        }
+        public void Warn(string message, Exception exception) => logger.LogWarning(exception, message);
 
-        public void WarnFormat(string format, params object[] args)
-        {
-            logger.LogWarning(format, args);
-        }
+        public void WarnFormat(string format, params object[] args) => logger.LogWarning(format, args);
 
-        public void Error(string message)
-        {
-            logger.LogError(message);
-        }
+        public void Error(string message) => logger.LogError(message);
 
-        public void Error(string message, Exception exception)
-        {
-            logger.LogError(exception, message);
-        }
+        public void Error(string message, Exception exception) => logger.LogError(exception, message);
 
-        public void ErrorFormat(string format, params object[] args)
-        {
-            logger.LogError(format, args);
-        }
+        public void ErrorFormat(string format, params object[] args) => logger.LogError(format, args);
 
-        public void Fatal(string message)
-        {
-            logger.LogCritical(message);
-        }
+        public void Fatal(string message) => logger.LogCritical(message);
 
-        public void Fatal(string message, Exception exception)
-        {
-            logger.LogCritical(exception, message);
-        }
+        public void Fatal(string message, Exception exception) => logger.LogCritical(exception, message);
 
-        public void FatalFormat(string format, params object[] args)
-        {
-            logger.LogCritical(format, args);
-        }
+        public void FatalFormat(string format, params object[] args) => logger.LogCritical(format, args);
 
-        ILogger logger;
+        ILogger logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/Logger.cs
@@ -3,6 +3,7 @@
     using System;
     using Logging;
     using Microsoft.Extensions.Logging;
+
     using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
     class Logger(ILogger logger) : ILog
@@ -47,6 +48,6 @@
 
         public void FatalFormat(string format, params object[] args) => logger.LogCritical(format, args);
 
-        ILogger logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        readonly ILogger logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Logging;
+
     using IMsLoggingFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     class LoggerFactory(IMsLoggingFactory loggerFactory) : ILoggerFactory
@@ -10,6 +11,6 @@
 
         public ILog GetLogger(string name) => new Logger(loggerFactory.CreateLogger(name));
 
-        IMsLoggingFactory loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        readonly IMsLoggingFactory loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
+++ b/src/NServiceBus.Extensions.Hosting/Logging/LoggerFactory.cs
@@ -4,17 +4,12 @@
     using Logging;
     using IMsLoggingFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
-    class LoggerFactory : ILoggerFactory
+    class LoggerFactory(IMsLoggingFactory loggerFactory) : ILoggerFactory
     {
-        public LoggerFactory(IMsLoggingFactory loggerFactory)
-        {
-            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
         public ILog GetLogger(Type type) => new Logger(loggerFactory.CreateLogger(type.FullName));
 
         public ILog GetLogger(string name) => new Logger(loggerFactory.CreateLogger(name));
 
-        IMsLoggingFactory loggerFactory;
+        IMsLoggingFactory loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
     }
 }

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusHostedService.cs
@@ -1,47 +1,16 @@
 ﻿namespace NServiceBus.Extensions.Hosting
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Logging;
     using Microsoft.Extensions.Hosting;
 
-    using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
-
-    class NServiceBusHostedService : IHostedService
+    class NServiceBusHostedService(EndpointStarter endpointStarter) : IHostedService
     {
-        public NServiceBusHostedService(IStartableEndpointWithExternallyManagedContainer startableEndpoint,
-            IServiceProvider serviceProvider,
-            ILoggerFactory loggerFactory,
-            DeferredLoggerFactory deferredLoggerFactory,
-            HostAwareMessageSession hostAwareMessageSession)
-        {
-            this.loggerFactory = loggerFactory;
-            this.deferredLoggerFactory = deferredLoggerFactory;
-            this.hostAwareMessageSession = hostAwareMessageSession;
-            this.startableEndpoint = startableEndpoint;
-            this.serviceProvider = serviceProvider;
-        }
-
         public async Task StartAsync(CancellationToken cancellationToken = default)
-        {
-            LogManager.UseFactory(new LoggerFactory(loggerFactory));
-            deferredLoggerFactory.FlushAll(loggerFactory);
-
-            endpoint = await startableEndpoint.Start(serviceProvider, cancellationToken)
-                .ConfigureAwait(false);
-
-            hostAwareMessageSession.MarkReadyForUse();
-        }
+            => endpoint = await endpointStarter.GetOrStart(cancellationToken).ConfigureAwait(false);
 
         public Task StopAsync(CancellationToken cancellationToken = default) =>
             endpoint?.Stop(cancellationToken) ?? Task.CompletedTask;
-
-        readonly IStartableEndpointWithExternallyManagedContainer startableEndpoint;
-        readonly IServiceProvider serviceProvider;
-        readonly DeferredLoggerFactory deferredLoggerFactory;
-        readonly HostAwareMessageSession hostAwareMessageSession;
-        readonly ILoggerFactory loggerFactory;
 
         IEndpointInstance endpoint;
     }

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+namespace NServiceBus.Extensions.Hosting
+{
+    using Microsoft.Extensions.DependencyInjection;
+
+    using MicrosoftILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+
+    static class NServiceBusServiceCollectionExtensions
+    {
+        public static void AddNServiceBus(this IServiceCollection services, EndpointConfiguration endpointConfiguration, DeferredLoggerFactory loggerFactory)
+        {
+            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, services);
+
+            services.AddSingleton(serviceProvider => new EndpointStarter(
+                startableEndpoint,
+                serviceProvider,
+                serviceProvider.GetRequiredService<MicrosoftILoggerFactory>(),
+                loggerFactory));
+            services.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
+            services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
+            services.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));
+        }
+    }
+}

--- a/src/NServiceBus.Extensions.Hosting/NServiceBusServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/NServiceBusServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Extensions.Hosting
 {
     using Microsoft.Extensions.DependencyInjection;
-
     using MicrosoftILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
     static class NServiceBusServiceCollectionExtensions

--- a/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.Hosting/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 namespace NServiceBus.Extensions.Hosting
 {
     using Microsoft.Extensions.DependencyInjection;
+
     using MicrosoftILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
-    static class NServiceBusServiceCollectionExtensions
+    static class ServiceCollectionExtensions
     {
         public static void AddNServiceBus(this IServiceCollection services, EndpointConfiguration endpointConfiguration, DeferredLoggerFactory loggerFactory)
         {
@@ -14,6 +15,7 @@ namespace NServiceBus.Extensions.Hosting
                 serviceProvider,
                 serviceProvider.GetRequiredService<MicrosoftILoggerFactory>(),
                 loggerFactory));
+
             services.AddSingleton(serviceProvider => new HostAwareMessageSession(serviceProvider.GetRequiredService<EndpointStarter>()));
             services.AddSingleton<IMessageSession>(serviceProvider => serviceProvider.GetRequiredService<HostAwareMessageSession>());
             services.AddHostedService(serviceProvider => new NServiceBusHostedService(serviceProvider.GetRequiredService<EndpointStarter>()));


### PR DESCRIPTION
This PR changes the way the endpoint is started to make it more user-friendly. Today, the order when someone calls `UseNServiceBus` matters, which complicates the user experience. Furthermore, it is not possible to use the new net8 concurrent hosted service start feature because hosted services might depend on the message session which might not yet be initialized.

This PR still uses a hosted service that will start NServiceBus but allows meanwhile the session to be retrieved and accessed. In cases where the session is accessed, but the endpoint is not yet started, the code trying to access the session operation will have to asynchronously yield slightly until the endpoint is started.